### PR TITLE
Improve graph interactions

### DIFF
--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
@@ -63,6 +63,7 @@ interface CameraPoint {
 
 const NODE_GEOMETRY = new SphereGeometry(1, 24, 16);
 const GRAPH_3D_SETTINGS = GRAPH_SETTINGS_DEFAULTS;
+const GRAPH_3D_NODE_REL_SIZE = 1;
 const Graph3DConstructor = ForceGraph3D as unknown as Graph3DConstructor;
 const DENSE_GRAPH_NODE_COUNT = 500;
 const LARGE_GRAPH_NODE_COUNT = 1_000;
@@ -99,8 +100,8 @@ function nodeOpacity(options: NodeOpacityOptions): number {
 }
 
 function nodeScale(radius: number, highlighted: boolean, softHighlighted: boolean): number {
-  if (highlighted) return radius * 1.12;
-  if (softHighlighted) return radius * 1.04;
+  if (highlighted) return radius;
+  if (softHighlighted) return radius;
   return radius;
 }
 
@@ -115,6 +116,10 @@ function nodeRadius(node: FGNode): number {
     cfg.nodeMinSize,
     Math.min(cfg.nodeMaxSize, cfg.nodeMinSize + node.linkCount * cfg.nodeSizeScale),
   );
+}
+
+function nodeVisualRadius(node: FGNode): number {
+  return Math.cbrt(Math.max(2, nodeRadius(node))) * GRAPH_3D_NODE_REL_SIZE;
 }
 
 function cameraDistanceForZoom(cameraPosition: { x: number; y: number; z: number }, scale: number) {
@@ -378,7 +383,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   function nodeThreeObject(node: FGNode): Group | undefined {
     if (!shouldUseCustomNodeObject(node)) return undefined;
 
-    const radius = nodeRadius(node);
+    const radius = nodeVisualRadius(node);
     const color = nodeColor(node);
     const group = new Group();
     const selected = node.filePath === selectedNode();
@@ -409,7 +414,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       const labelColor = getEffectiveTheme() === "dark" ? "#f7f4ff" : "#1d172b";
       const label = new SpriteText(
         shortLabel(node.name),
-        focusedFilePath() === node.filePath ? 4.4 : 3.4,
+        focusedFilePath() === node.filePath ? 3.4 : 2.7,
         labelColor,
       );
       label.fontFace = "Goorm Sans, -apple-system, BlinkMacSystemFont, sans-serif";
@@ -420,8 +425,8 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       label.borderColor = labelBorderColor(node);
       label.borderWidth = focusedFilePath() === node.filePath ? 0.55 : 0.25;
       label.borderRadius = 2;
-      label.padding = focusedFilePath() === node.filePath ? [4, 3] : [3, 2];
-      label.position.y = radius + (focusedFilePath() === node.filePath ? 10 : 6.8);
+      label.padding = focusedFilePath() === node.filePath ? [3, 2] : [2, 1.5];
+      label.position.y = radius + (focusedFilePath() === node.filePath ? 7 : 4.8);
       label.renderOrder = 1000;
       label.material.depthTest = false;
       label.material.depthWrite = false;
@@ -652,7 +657,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
         .nodeVal((node) => Math.max(2, nodeRadius(node)))
         .nodeColor((node) => nodeColor(node))
         .nodeThreeObject((node) => nodeThreeObject(node) as Group)
-        .nodeRelSize(1)
+        .nodeRelSize(GRAPH_3D_NODE_REL_SIZE)
         .nodeResolution(nodeResolutionForBudget())
         .linkColor((link) => linkColor(link))
         .linkWidth((link) => linkWidth(link))

--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_pixi.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_pixi.tsx
@@ -199,6 +199,10 @@ function easeInOutCubic(progress: number): number {
   return progress < 0.5 ? 4 * progress * progress * progress : 1 - (-2 * progress + 2) ** 3 / 2;
 }
 
+function easeOutCubic(progress: number): number {
+  return 1 - (1 - progress) ** 3;
+}
+
 export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
   let hostEl: HTMLDivElement | undefined;
   let app: Application | undefined;
@@ -211,6 +215,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
   let destroyed = false;
   let renderFrame: number | undefined;
   let viewAnimationFrame: number | undefined;
+  let viewInertiaFrame: number | undefined;
   let layoutRelaxFrame: number | undefined;
   let layoutRelaxTicks = 0;
   let layoutRelaxCooling = 1;
@@ -218,7 +223,16 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
   let redrawLinksOnNextDraw = true;
   let redrawClustersOnNextDraw = true;
   let hoverFrame: number | undefined;
-  let dragStart: { x: number; y: number; view: ViewState } | null = null;
+  let dragStart: {
+    x: number;
+    y: number;
+    lastX: number;
+    lastY: number;
+    lastAt: number;
+    velocityX: number;
+    velocityY: number;
+    view: ViewState;
+  } | null = null;
   let nodeDrag: {
     node: LayoutNode;
     startClientX: number;
@@ -631,7 +645,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
         redrawStructuralLayers = layoutRelaxDrawTick % 2 === 0 || layoutRelaxTicks <= 1;
       }
       requestDraw({ links: redrawStructuralLayers, clusters: redrawStructuralLayers });
-      if (layoutRelaxTicks > 0 && (layoutRelaxCooling > 0.025 || maxSpeed > 0.035)) {
+      if (layoutRelaxTicks > 0 && (layoutRelaxCooling > 0.006 || maxSpeed > 0.008)) {
         layoutRelaxFrame = requestAnimationFrame(step);
       }
     };
@@ -1239,8 +1253,15 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
     viewAnimationFrame = undefined;
   }
 
+  function cancelViewInertia(): void {
+    if (viewInertiaFrame === undefined) return;
+    cancelAnimationFrame(viewInertiaFrame);
+    viewInertiaFrame = undefined;
+  }
+
   function animateView(nextView: ViewState, duration = 850): void {
     cancelViewAnimation();
+    cancelViewInertia();
     const start = { ...view };
     const startedAt = performance.now();
     const step = (now: number) => {
@@ -1263,6 +1284,37 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
     viewAnimationFrame = requestAnimationFrame(step);
   }
 
+  function startViewInertia(velocityX: number, velocityY: number): void {
+    cancelViewInertia();
+    if (Math.hypot(velocityX, velocityY) < 0.018) return;
+
+    let vx = velocityX;
+    let vy = velocityY;
+    let lastAt = performance.now();
+    const startedAt = lastAt;
+
+    const step = (now: number) => {
+      viewInertiaFrame = undefined;
+      if (destroyed) return;
+
+      const dt = Math.min(34, now - lastAt);
+      lastAt = now;
+      view.x += vx * dt;
+      view.y += vy * dt;
+
+      const decay = Math.exp(-dt / 260);
+      vx *= decay;
+      vy *= decay;
+      requestDraw();
+
+      if (now - startedAt < 900 && Math.hypot(vx, vy) > 0.01) {
+        viewInertiaFrame = requestAnimationFrame(step);
+      }
+    };
+
+    viewInertiaFrame = requestAnimationFrame(step);
+  }
+
   function followCurrentFile(): void {
     const next = !followMode();
     setFollowMode(next);
@@ -1279,23 +1331,53 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
     return 1.9;
   }
 
-  function zoomAt(centerX: number, centerY: number, nextScale: number): void {
+  function zoomAt(centerX: number, centerY: number, nextScale: number, duration = 220): void {
     cancelViewAnimation();
+    cancelViewInertia();
     const before = screenToGraph(centerX, centerY);
-    view.scale = Math.max(0.08, Math.min(8, nextScale));
-    view.x = centerX - before.x * view.scale;
-    view.y = centerY - before.y * view.scale;
-    requestDraw({ links: true, clusters: true });
+    const scale = Math.max(0.08, Math.min(8, nextScale));
+    const nextView = {
+      scale,
+      x: centerX - before.x * scale,
+      y: centerY - before.y * scale,
+    };
+    if (duration <= 0) {
+      view = nextView;
+      requestDraw({ links: true, clusters: true });
+      return;
+    }
+
+    const start = { ...view };
+    const startedAt = performance.now();
+    const step = (now: number) => {
+      viewAnimationFrame = undefined;
+      if (destroyed) return;
+      const progress = Math.min(1, (now - startedAt) / duration);
+      const eased = easeOutCubic(progress);
+      view = {
+        x: start.x + (nextView.x - start.x) * eased,
+        y: start.y + (nextView.y - start.y) * eased,
+        scale: start.scale + (nextView.scale - start.scale) * eased,
+      };
+      requestDraw({ links: true, clusters: true });
+      if (progress < 1) {
+        viewAnimationFrame = requestAnimationFrame(step);
+      } else {
+        view = nextView;
+        requestDraw({ links: true, clusters: true });
+      }
+    };
+    viewAnimationFrame = requestAnimationFrame(step);
   }
 
   function zoomIn(): void {
     const { width, height } = dimensions();
-    zoomAt(width / 2, height / 2, view.scale * 1.3);
+    zoomAt(width / 2, height / 2, view.scale * 1.3, 280);
   }
 
   function zoomOut(): void {
     const { width, height } = dimensions();
-    zoomAt(width / 2, height / 2, view.scale / 1.3);
+    zoomAt(width / 2, height / 2, view.scale / 1.3, 280);
   }
 
   function resetView(): void {
@@ -1397,6 +1479,15 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
       return;
     }
     if (dragStart) {
+      const now = performance.now();
+      const dt = Math.max(1, now - dragStart.lastAt);
+      const instantVelocityX = (event.clientX - dragStart.lastX) / dt;
+      const instantVelocityY = (event.clientY - dragStart.lastY) / dt;
+      dragStart.velocityX = dragStart.velocityX * 0.58 + instantVelocityX * 0.42;
+      dragStart.velocityY = dragStart.velocityY * 0.58 + instantVelocityY * 0.42;
+      dragStart.lastX = event.clientX;
+      dragStart.lastY = event.clientY;
+      dragStart.lastAt = now;
       view.x = dragStart.view.x + event.clientX - dragStart.x;
       view.y = dragStart.view.y + event.clientY - dragStart.y;
       requestDraw();
@@ -1412,6 +1503,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
   function handlePointerDown(event: PointerEvent): void {
     if (event.button !== 0) return;
     cancelViewAnimation();
+    cancelViewInertia();
     cancelLayoutRelaxation();
     const node = nearestNode(event.clientX, event.clientY);
     if (node) {
@@ -1428,7 +1520,16 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
       hostEl?.setPointerCapture(event.pointerId);
       return;
     }
-    dragStart = { x: event.clientX, y: event.clientY, view: { ...view } };
+    dragStart = {
+      x: event.clientX,
+      y: event.clientY,
+      lastX: event.clientX,
+      lastY: event.clientY,
+      lastAt: performance.now(),
+      velocityX: 0,
+      velocityY: 0,
+      view: { ...view },
+    };
     hostEl?.setPointerCapture(event.pointerId);
   }
 
@@ -1443,7 +1544,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
         dragged.node.vx = 0;
         dragged.node.vy = 0;
         setSelectedNode(dragged.node.filePath);
-        startLayoutRelaxation(isHugeGraph() ? 96 : 150);
+        startLayoutRelaxation(isHugeGraph() ? 130 : 210);
         requestDraw({ links: true, clusters: true });
         return;
       }
@@ -1453,10 +1554,14 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
       return;
     }
     if (!dragStart) return;
+    const pan = dragStart;
     const moved = Math.hypot(event.clientX - dragStart.x, event.clientY - dragStart.y);
     dragStart = null;
     hostEl?.releasePointerCapture(event.pointerId);
-    if (moved > 5) return;
+    if (moved > 5) {
+      startViewInertia(pan.velocityX, pan.velocityY);
+      return;
+    }
     const node = nearestNode(event.clientX, event.clientY);
     if (node) {
       setSelectedNode(node.filePath);
@@ -1473,7 +1578,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
     if (!hostEl) return;
     const rect = hostEl.getBoundingClientRect();
     const factor = event.deltaY > 0 ? 0.86 : 1.16;
-    zoomAt(event.clientX - rect.left, event.clientY - rect.top, view.scale * factor);
+    zoomAt(event.clientX - rect.left, event.clientY - rect.top, view.scale * factor, 170);
   }
 
   function handleContextMenu(event: MouseEvent): void {
@@ -1650,6 +1755,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
     destroyed = true;
     if (renderFrame !== undefined) cancelAnimationFrame(renderFrame);
     if (viewAnimationFrame !== undefined) cancelAnimationFrame(viewAnimationFrame);
+    if (viewInertiaFrame !== undefined) cancelAnimationFrame(viewInertiaFrame);
     if (layoutRelaxFrame !== undefined) cancelAnimationFrame(layoutRelaxFrame);
     if (hoverFrame !== undefined) cancelAnimationFrame(hoverFrame);
     resizeObs?.disconnect();


### PR DESCRIPTION
## Summary
- Align 3D hover node sizing with the graph renderer's base node radius calculation.
- Remove the extra 3D hover scale jump and reduce hover label size/offset.
- Smooth 2D graph interactions with eased zoom, pan inertia, and longer layout relaxation.

## Impact
Graph hover states should feel less oversized in 3D, and 2D graph pan/zoom/layout motion should ease out instead of stopping abruptly.

## Validation
- `pnpm --filter @kuku/desktop build`
