### PR TITLE
feat: seed new notes with headings

### DIFF
--- a/apps/desktop/src/stores/__tests__/vault_actions.test.ts
+++ b/apps/desktop/src/stores/__tests__/vault_actions.test.ts
@@ -4,6 +4,7 @@ const mockListVaultFiles = vi.fn();
 const mockVaultRename = vi.fn();
 const mockVaultDelete = vi.fn();
 const mockVaultGetTrashPath = vi.fn();
+const mockWriteVaultFile = vi.fn();
 const mockListen = vi.fn().mockResolvedValue(() => {});
 const mockGetActiveTab = vi.fn();
 const mockGetEditorDocumentSession = vi.fn();
@@ -72,7 +73,7 @@ vi.mock("~/lib/vault_fs", () => ({
   vaultGetTrashPath: mockVaultGetTrashPath,
   vaultMkdir: vi.fn(),
   vaultRename: mockVaultRename,
-  writeVaultFile: vi.fn(),
+  writeVaultFile: mockWriteVaultFile,
   writeVaultFileWithChecksum: vi.fn(),
 }));
 
@@ -97,6 +98,7 @@ describe("vault actions", () => {
     mockVaultRename.mockReset().mockResolvedValue(undefined);
     mockVaultDelete.mockReset().mockResolvedValue(undefined);
     mockVaultGetTrashPath.mockReset().mockResolvedValue("/tmp/vault/.trash");
+    mockWriteVaultFile.mockReset().mockResolvedValue(undefined);
     mockGetActiveTab.mockReset().mockReturnValue(undefined);
     mockGetEditorDocumentSession.mockReset().mockReturnValue(null);
     mockRenameTabsForMovedPath.mockReset();
@@ -213,6 +215,26 @@ describe("vault actions", () => {
 
     expect(mockVaultDelete).toHaveBeenCalledWith("notes/a.md", "kuku-trash");
     expect(mockCloseTabsForDeletedPath).toHaveBeenCalledWith("notes/a.md", false);
+  });
+
+  it("starts new files with a heading based on the generated filename", async () => {
+    const vault = await loadVaultModule();
+
+    await vault.loadFiles("/tmp/vault");
+    await vault.createAndOpenNewFile();
+
+    expect(mockWriteVaultFile).toHaveBeenCalledWith("Untitled.md", "# Untitled\n\n");
+  });
+
+  it("starts inline-created markdown files with a heading based on the entered name", async () => {
+    const vault = await loadVaultModule();
+
+    await vault.loadFiles("/tmp/vault");
+    vault.startCreateFile();
+    vault.updateEditName("Project Plan");
+    await vault.confirmEdit();
+
+    expect(mockWriteVaultFile).toHaveBeenCalledWith("Project Plan.md", "# Project Plan\n\n");
   });
 
   it("reloads the clean active editor when a watcher event modifies its file", async () => {

--- a/apps/desktop/src/stores/vault.ts
+++ b/apps/desktop/src/stores/vault.ts
@@ -276,6 +276,11 @@ function isFolderExpanded(path: string): boolean {
   return vaultState.expandedFolders.has(path);
 }
 
+function initialMarkdownForFileName(fileName: string): string {
+  const title = fileName.replace(/\.(md|markdown)$/i, "").trim() || "Untitled";
+  return `# ${title}\n\n`;
+}
+
 async function createAndOpenNewFile(): Promise<void> {
   const root = vaultState.rootPath;
   if (!root) {
@@ -302,7 +307,7 @@ async function createAndOpenNewFile(): Promise<void> {
     counter++;
   }
 
-  await writeVaultFile(filePath, "");
+  await writeVaultFile(filePath, initialMarkdownForFileName(fileName));
   await loadFiles(root);
   openTab(fileName, filePath);
   const tab = getActiveTab();
@@ -520,7 +525,7 @@ async function confirmEdit(): Promise<void> {
         const finalPath = destinationPath.endsWith(".md")
           ? destinationPath
           : `${destinationPath}.md`;
-        await writeVaultFile(finalPath, "");
+        await writeVaultFile(finalPath, initialMarkdownForFileName(nextName));
       }
       await loadFiles(root);
       return;


### PR DESCRIPTION
## Summary
- seed newly created markdown files with an H1 based on the filename
- cover generated and inline-created file flows with focused vault action tests

## Tests
- pnpm --dir apps/desktop exec vitest run src/stores/__tests__/vault_actions.test.ts
- pnpm --dir apps/desktop exec tsc --noEmit