### PR TITLE
Add H1 content for new documents

### DIFF
--- a/apps/desktop/src/stores/__tests__/vault_actions.test.ts
+++ b/apps/desktop/src/stores/__tests__/vault_actions.test.ts
@@ -4,6 +4,7 @@ const mockListVaultFiles = vi.fn();
 const mockVaultRename = vi.fn();
 const mockVaultDelete = vi.fn();
 const mockVaultGetTrashPath = vi.fn();
+const mockWriteVaultFile = vi.fn();
 const mockListen = vi.fn().mockResolvedValue(() => {});
 const mockGetActiveTab = vi.fn();
 const mockGetEditorDocumentSession = vi.fn();
@@ -72,7 +73,7 @@ vi.mock("~/lib/vault_fs", () => ({
   vaultGetTrashPath: mockVaultGetTrashPath,
   vaultMkdir: vi.fn(),
   vaultRename: mockVaultRename,
-  writeVaultFile: vi.fn(),
+  writeVaultFile: mockWriteVaultFile,
   writeVaultFileWithChecksum: vi.fn(),
 }));
 
@@ -97,6 +98,7 @@ describe("vault actions", () => {
     mockVaultRename.mockReset().mockResolvedValue(undefined);
     mockVaultDelete.mockReset().mockResolvedValue(undefined);
     mockVaultGetTrashPath.mockReset().mockResolvedValue("/tmp/vault/.trash");
+    mockWriteVaultFile.mockReset().mockResolvedValue(undefined);
     mockGetActiveTab.mockReset().mockReturnValue(undefined);
     mockGetEditorDocumentSession.mockReset().mockReturnValue(null);
     mockRenameTabsForMovedPath.mockReset();
@@ -187,6 +189,26 @@ describe("vault actions", () => {
     expect(vault.vaultState.editState).toBeNull();
     expect(mockVaultRename).not.toHaveBeenCalled();
     expect(mockRenameTabsForMovedPath).not.toHaveBeenCalled();
+  });
+
+  it("creates a quick new document with an H1 based on the generated file name", async () => {
+    const vault = await loadVaultModule();
+
+    await vault.loadFiles("/tmp/vault");
+    await vault.createAndOpenNewFile();
+
+    expect(mockWriteVaultFile).toHaveBeenCalledWith("Untitled.md", "# Untitled\n\n");
+  });
+
+  it("creates an inline new document with an H1 based on the edited file name", async () => {
+    const vault = await loadVaultModule();
+
+    await vault.loadFiles("/tmp/vault");
+    vault.startCreateFile();
+    vault.updateEditName("Project Plan");
+    await vault.confirmEdit();
+
+    expect(mockWriteVaultFile).toHaveBeenCalledWith("Project Plan.md", "# Project Plan\n\n");
   });
 
   it("keeps tabs and edit state intact when delete fails", async () => {

--- a/apps/desktop/src/stores/vault.ts
+++ b/apps/desktop/src/stores/vault.ts
@@ -25,6 +25,7 @@ import { getEditorDocumentSession } from "~/stores/editor";
 import { emitEvent } from "~/plugins/events";
 import {
   buildNameFromEditable,
+  getPathName,
   getParentPath,
   joinVaultPath,
   isSameOrDescendantPath,
@@ -276,6 +277,12 @@ function isFolderExpanded(path: string): boolean {
   return vaultState.expandedFolders.has(path);
 }
 
+function createNewDocumentContent(filePath: string): string {
+  const fileName = getPathName(filePath);
+  const title = fileName.endsWith(".md") ? fileName.slice(0, -3) : fileName;
+  return `# ${title}\n\n`;
+}
+
 async function createAndOpenNewFile(): Promise<void> {
   const root = vaultState.rootPath;
   if (!root) {
@@ -302,7 +309,7 @@ async function createAndOpenNewFile(): Promise<void> {
     counter++;
   }
 
-  await writeVaultFile(filePath, "");
+  await writeVaultFile(filePath, createNewDocumentContent(filePath));
   await loadFiles(root);
   openTab(fileName, filePath);
   const tab = getActiveTab();
@@ -520,7 +527,7 @@ async function confirmEdit(): Promise<void> {
         const finalPath = destinationPath.endsWith(".md")
           ? destinationPath
           : `${destinationPath}.md`;
-        await writeVaultFile(finalPath, "");
+        await writeVaultFile(finalPath, createNewDocumentContent(finalPath));
       }
       await loadFiles(root);
       return;


### PR DESCRIPTION
## Summary
- initialize newly created markdown documents with an H1 derived from the file name
- cover both quick new-file creation and inline vault-browser creation paths

## Tests
- pnpm --dir apps/desktop exec vitest run
- pnpm --dir apps/desktop exec tsc -p tsconfig.app.json --noEmit