### PR TITLE
feat: add ai tool permission metadata

### DIFF
--- a/apps/desktop/src-tauri/src/ai_tools/document_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/document_tools.rs
@@ -1,11 +1,11 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
+use kuku_ai::ChatMode;
 use kuku_ai::{
     AiNativeTool, NativeToolResult, ToolAccess, ToolCallContext, ToolDescriptor, ToolError,
     ToolKind, ToolRiskLevel, ToolSource,
 };
-use kuku_ai::ChatMode;
 use kuku_indexer::extract_document;
 use serde::Serialize;
 use tauri::{AppHandle, Manager};

--- a/apps/desktop/src-tauri/src/ai_tools/document_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/document_tools.rs
@@ -3,8 +3,9 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use kuku_ai::{
     AiNativeTool, NativeToolResult, ToolAccess, ToolCallContext, ToolDescriptor, ToolError,
-    ToolSource,
+    ToolKind, ToolRiskLevel, ToolSource,
 };
+use kuku_ai::ChatMode;
 use kuku_indexer::extract_document;
 use serde::Serialize;
 use tauri::{AppHandle, Manager};
@@ -137,6 +138,11 @@ fn descriptor(
         description: description.to_string(),
         parameters,
         category: "document".to_string(),
+        kind: ToolKind::Read,
+        requires_approval: false,
+        risk_level: ToolRiskLevel::Low,
+        mode_availability: vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent],
+        permission_rule_key: tool_id.to_string(),
         access: ToolAccess::ReadOnly,
         source: ToolSource::Native,
     }

--- a/apps/desktop/src-tauri/src/ai_tools/file_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/file_tools.rs
@@ -390,35 +390,35 @@ fn descriptor(
 ) -> ToolDescriptor {
     debug_assert_eq!(tool_ids::canonical_builtin_tool_id(name), tool_id);
 
-        ToolDescriptor {
-            tool_id: tool_id.to_string(),
-            name: name.to_string(),
-            description: description.to_string(),
-            parameters,
-            category: category.to_string(),
-            kind: if access == ToolAccess::ReadOnly {
-                ToolKind::Read
-            } else {
-                ToolKind::Edit
-            },
-            requires_approval: access == ToolAccess::ProposesMutation,
-            risk_level: match name {
-                "delete_file" => ToolRiskLevel::High,
-                "create_file" | "edit_file" | "move_file" => ToolRiskLevel::Medium,
-                _ => ToolRiskLevel::Low,
-            },
-            mode_availability: match name {
-                "edit_file" => vec![ChatMode::Inline, ChatMode::Agent],
-                _ if access == ToolAccess::ReadOnly => {
-                    vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent]
-                }
-                _ => vec![ChatMode::Agent],
-            },
-            permission_rule_key: tool_id.to_string(),
-            access,
-            source: ToolSource::Native,
-        }
+    ToolDescriptor {
+        tool_id: tool_id.to_string(),
+        name: name.to_string(),
+        description: description.to_string(),
+        parameters,
+        category: category.to_string(),
+        kind: if access == ToolAccess::ReadOnly {
+            ToolKind::Read
+        } else {
+            ToolKind::Edit
+        },
+        requires_approval: access == ToolAccess::ProposesMutation,
+        risk_level: match name {
+            "delete_file" => ToolRiskLevel::High,
+            "create_file" | "edit_file" | "move_file" => ToolRiskLevel::Medium,
+            _ => ToolRiskLevel::Low,
+        },
+        mode_availability: match name {
+            "edit_file" => vec![ChatMode::Inline, ChatMode::Agent],
+            _ if access == ToolAccess::ReadOnly => {
+                vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent]
+            }
+            _ => vec![ChatMode::Agent],
+        },
+        permission_rule_key: tool_id.to_string(),
+        access,
+        source: ToolSource::Native,
     }
+}
 
 fn path_arg(args: &serde_json::Value) -> Option<String> {
     optional_path_arg(args).filter(|value| !value.is_empty())

--- a/apps/desktop/src-tauri/src/ai_tools/file_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/file_tools.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use kuku_ai::{
     AiNativeTool, AiState, ChatMode, MutationOp, MutationPlan, NativeToolResult, ToolAccess,
-    ToolCallContext, ToolDescriptor, ToolError, ToolSource,
+    ToolCallContext, ToolDescriptor, ToolError, ToolKind, ToolRiskLevel, ToolSource,
 };
 use tauri::{AppHandle, Manager};
 
@@ -390,16 +390,35 @@ fn descriptor(
 ) -> ToolDescriptor {
     debug_assert_eq!(tool_ids::canonical_builtin_tool_id(name), tool_id);
 
-    ToolDescriptor {
-        tool_id: tool_id.to_string(),
-        name: name.to_string(),
-        description: description.to_string(),
-        parameters,
-        category: category.to_string(),
-        access,
-        source: ToolSource::Native,
+        ToolDescriptor {
+            tool_id: tool_id.to_string(),
+            name: name.to_string(),
+            description: description.to_string(),
+            parameters,
+            category: category.to_string(),
+            kind: if access == ToolAccess::ReadOnly {
+                ToolKind::Read
+            } else {
+                ToolKind::Edit
+            },
+            requires_approval: access == ToolAccess::ProposesMutation,
+            risk_level: match name {
+                "delete_file" => ToolRiskLevel::High,
+                "create_file" | "edit_file" | "move_file" => ToolRiskLevel::Medium,
+                _ => ToolRiskLevel::Low,
+            },
+            mode_availability: match name {
+                "edit_file" => vec![ChatMode::Inline, ChatMode::Agent],
+                _ if access == ToolAccess::ReadOnly => {
+                    vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent]
+                }
+                _ => vec![ChatMode::Agent],
+            },
+            permission_rule_key: tool_id.to_string(),
+            access,
+            source: ToolSource::Native,
+        }
     }
-}
 
 fn path_arg(args: &serde_json::Value) -> Option<String> {
     optional_path_arg(args).filter(|value| !value.is_empty())

--- a/apps/desktop/src-tauri/src/ai_tools/search_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/search_tools.rs
@@ -1,8 +1,9 @@
 use async_trait::async_trait;
 use kuku_ai::{
     AiNativeTool, NativeToolResult, ToolAccess, ToolCallContext, ToolDescriptor, ToolError,
-    ToolSource,
+    ToolKind, ToolRiskLevel, ToolSource,
 };
+use kuku_ai::ChatMode;
 use tauri::Manager;
 
 use crate::search::SearchState;
@@ -28,6 +29,11 @@ impl AiNativeTool for SearchVaultTool {
                 "required": ["query"]
             }),
             category: "search".into(),
+            kind: ToolKind::Search,
+            requires_approval: false,
+            risk_level: ToolRiskLevel::Low,
+            mode_availability: vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent],
+            permission_rule_key: tool_ids::SEARCH_VAULT.into(),
             access: ToolAccess::ReadOnly,
             source: ToolSource::Native,
         }

--- a/apps/desktop/src-tauri/src/ai_tools/search_tools.rs
+++ b/apps/desktop/src-tauri/src/ai_tools/search_tools.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
+use kuku_ai::ChatMode;
 use kuku_ai::{
     AiNativeTool, NativeToolResult, ToolAccess, ToolCallContext, ToolDescriptor, ToolError,
     ToolKind, ToolRiskLevel, ToolSource,
 };
-use kuku_ai::ChatMode;
 use tauri::Manager;
 
 use crate::search::SearchState;

--- a/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
@@ -92,12 +92,46 @@ describe("proxy tool bridge", () => {
     const dispose = await createProxyToolBridge(registry);
     await flushPromises();
 
-    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(registerCallCount()).toBe(1);
 
     listener?.();
     await flushPromises();
 
-    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(registerCallCount()).toBe(2);
+
+    dispose();
+  });
+
+  it("clears stale Rust proxy descriptors when registration fails", async () => {
+    const registry = createRegistry([
+      {
+        name: "memory_context",
+        toolId: "knowledge.memory_context",
+        description: "Read committed Knowledge memory.",
+        category: "knowledge",
+        parameters: { type: "object", properties: {} },
+        access: "readOnly",
+        kind: "read",
+        riskLevel: "low",
+        requiresApproval: false,
+        modeAvailability: [],
+        permissionRuleKey: "knowledge.memory_context",
+        aiEnabled: true,
+      } as ProxyToolDescriptor,
+    ]);
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "plugin:kuku-ai|ai_register_proxy_tool") {
+        return Promise.reject(new Error("modeAvailability must contain at least one chat mode"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const dispose = await createProxyToolBridge(registry);
+    await flushPromises();
+
+    expect(invokeMock).toHaveBeenCalledWith("plugin:kuku-ai|ai_unregister_proxy_tool", {
+      name: "memory_context",
+    });
 
     dispose();
   });
@@ -128,4 +162,10 @@ async function flushPromises(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function registerCallCount(): number {
+  return invokeMock.mock.calls.filter(
+    ([command]) => command === "plugin:kuku-ai|ai_register_proxy_tool",
+  ).length;
 }

--- a/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AiProxyToolRegistry,
+  ProxyToolDescriptor,
+  ProxyToolSpec,
+} from "~/plugins/builtin/core_tool_registry/types";
+
+import { createProxyToolBridge } from "./proxy_tool_bridge";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+describe("proxy tool bridge", () => {
+  afterEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("passes permission metadata when registering proxy tools with Rust", async () => {
+    const registry = createRegistry([
+      {
+        name: "wiki_propose_page",
+        toolId: "knowledge.wiki_propose_page",
+        description: "Create a Knowledge decision document for review.",
+        category: "knowledge",
+        parameters: { type: "object", properties: {} },
+        access: "proposesMutation",
+        kind: "proposal",
+        riskLevel: "medium",
+        requiresApproval: true,
+        modeAvailability: ["agent"],
+        permissionRuleKey: "knowledge.wiki_propose_page",
+        aiEnabled: true,
+      } as ProxyToolDescriptor,
+    ]);
+
+    const dispose = await createProxyToolBridge(registry);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeMock).toHaveBeenCalledWith("plugin:kuku-ai|ai_register_proxy_tool", {
+      descriptor: expect.objectContaining({
+        toolId: "knowledge.wiki_propose_page",
+        name: "wiki_propose_page",
+        access: "proposesMutation",
+        kind: "proposal",
+        riskLevel: "medium",
+        requiresApproval: true,
+        modeAvailability: ["agent"],
+        permissionRuleKey: "knowledge.wiki_propose_page",
+      }),
+    });
+
+    dispose();
+  });
+});
+
+function createRegistry(tools: ProxyToolDescriptor[]): AiProxyToolRegistry {
+  return {
+    register() {
+      return () => {};
+    },
+    list() {
+      return tools;
+    },
+    getHandler(_name: string): ProxyToolSpec["handler"] | undefined {
+      return undefined;
+    },
+    subscribe() {
+      return () => {};
+    },
+  };
+}

--- a/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.test.ts
@@ -60,9 +60,53 @@ describe("proxy tool bridge", () => {
 
     dispose();
   });
+
+  it("retries failed proxy registrations on the next registry sync", async () => {
+    let listener: (() => void) | undefined;
+    const registry = createRegistry(
+      [
+        {
+          name: "memory_context",
+          toolId: "knowledge.memory_context",
+          description: "Read committed Knowledge memory.",
+          category: "knowledge",
+          parameters: { type: "object", properties: {} },
+          access: "readOnly",
+          kind: "read",
+          riskLevel: "low",
+          requiresApproval: false,
+          modeAvailability: ["ask", "inline", "agent"],
+          permissionRuleKey: "knowledge.memory_context",
+          aiEnabled: true,
+        } as ProxyToolDescriptor,
+      ],
+      (nextListener) => {
+        listener = nextListener;
+      },
+    );
+    invokeMock.mockResolvedValue(undefined);
+    invokeMock.mockRejectedValueOnce(
+      new Error("modeAvailability must contain at least one chat mode"),
+    );
+
+    const dispose = await createProxyToolBridge(registry);
+    await flushPromises();
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+
+    listener?.();
+    await flushPromises();
+
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+
+    dispose();
+  });
 });
 
-function createRegistry(tools: ProxyToolDescriptor[]): AiProxyToolRegistry {
+function createRegistry(
+  tools: ProxyToolDescriptor[],
+  onSubscribe?: (listener: () => void) => void,
+): AiProxyToolRegistry {
   return {
     register() {
       return () => {};
@@ -73,8 +117,15 @@ function createRegistry(tools: ProxyToolDescriptor[]): AiProxyToolRegistry {
     getHandler(_name: string): ProxyToolSpec["handler"] | undefined {
       return undefined;
     },
-    subscribe() {
+    subscribe(listener) {
+      onSubscribe?.(listener);
       return () => {};
     },
   };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.ts
@@ -57,6 +57,12 @@ async function createProxyToolBridge(
         } catch (error) {
           // eslint-disable-next-line no-console
           console.error("[ai-chat] failed to register proxy tool", error);
+          await invoke("plugin:kuku-ai|ai_unregister_proxy_tool", { name: tool.name }).catch(
+            (unregisterError) => {
+              // eslint-disable-next-line no-console
+              console.error("[ai-chat] failed to clear stale proxy tool", unregisterError);
+            },
+          );
         }
       }),
     );

--- a/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/proxy_tool_bridge.ts
@@ -45,6 +45,12 @@ async function createProxyToolBridge(
               description: tool.description,
               parameters: tool.parameters,
               category: tool.category,
+              access: tool.access,
+              kind: tool.kind,
+              riskLevel: tool.riskLevel,
+              requiresApproval: tool.requiresApproval,
+              modeAvailability: tool.modeAvailability,
+              permissionRuleKey: tool.permissionRuleKey,
             },
           });
           successfulNames.add(tool.name);

--- a/apps/desktop/src/plugins/builtin/ai_chat/types.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/types.ts
@@ -109,6 +109,11 @@ interface ToolDescriptor {
   category: string;
   access?: "readOnly" | "proposesMutation";
   source?: "native" | "proxy";
+  kind?: "read" | "search" | "edit" | "proposal" | "navigation" | "other";
+  riskLevel?: "low" | "medium" | "high";
+  requiresApproval?: boolean;
+  modeAvailability?: ChatMode[];
+  permissionRuleKey?: string;
 }
 
 interface ChatTextMessage {

--- a/apps/desktop/src/plugins/builtin/core_commands/index.ts
+++ b/apps/desktop/src/plugins/builtin/core_commands/index.ts
@@ -175,6 +175,12 @@ const coreCommandsPlugin: KukuPlugin = {
       description:
         "Open a vault file in an editor tab. This is a navigation action, not a mutation.",
       category: "navigation",
+      access: "readOnly",
+      kind: "navigation",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: `${ctx.pluginId}.open_file`,
       parameters: {
         type: "object",
         properties: {

--- a/apps/desktop/src/plugins/builtin/core_tool_registry/registry.test.ts
+++ b/apps/desktop/src/plugins/builtin/core_tool_registry/registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { createProxyToolRegistry } from "./registry";
+import type { ProxyToolSpec } from "./types";
+
+describe("proxy tool registry", () => {
+  it("preserves tool permission metadata in descriptors", () => {
+    const registry = createProxyToolRegistry();
+
+    registry.register({
+      name: "wiki_propose_page",
+      toolId: "knowledge.wiki_propose_page",
+      description: "Create a Knowledge decision document for review.",
+      category: "knowledge",
+      parameters: { type: "object", properties: {} },
+      access: "proposesMutation",
+      kind: "proposal",
+      riskLevel: "medium",
+      requiresApproval: true,
+      modeAvailability: ["agent"],
+      permissionRuleKey: "knowledge.wiki_propose_page",
+      handler: async () => "{}",
+    } as ProxyToolSpec);
+
+    expect(registry.list()[0]).toMatchObject({
+      name: "wiki_propose_page",
+      access: "proposesMutation",
+      kind: "proposal",
+      riskLevel: "medium",
+      requiresApproval: true,
+      modeAvailability: ["agent"],
+      permissionRuleKey: "knowledge.wiki_propose_page",
+    });
+  });
+});

--- a/apps/desktop/src/plugins/builtin/core_tool_registry/registry.ts
+++ b/apps/desktop/src/plugins/builtin/core_tool_registry/registry.ts
@@ -35,6 +35,12 @@ function createProxyToolRegistry(): AiProxyToolRegistry {
         description: tool.description,
         parameters: tool.parameters,
         category: tool.category,
+        access: tool.access,
+        kind: tool.kind,
+        riskLevel: tool.riskLevel,
+        requiresApproval: tool.requiresApproval,
+        modeAvailability: tool.modeAvailability,
+        permissionRuleKey: tool.permissionRuleKey,
         aiEnabled: tool.aiEnabled,
       }));
     },

--- a/apps/desktop/src/plugins/builtin/core_tool_registry/types.ts
+++ b/apps/desktop/src/plugins/builtin/core_tool_registry/types.ts
@@ -8,12 +8,23 @@ interface ProxyToolCallPayload {
   arguments: Record<string, unknown>;
 }
 
+type ProxyToolAccess = "readOnly" | "proposesMutation";
+type ProxyToolKind = "read" | "search" | "edit" | "proposal" | "navigation" | "other";
+type ProxyToolRiskLevel = "low" | "medium" | "high";
+type ProxyToolModeAvailability = "ask" | "agent" | "inline";
+
 interface ProxyToolSpec {
   name: string;
   toolId: string;
   description: string;
   parameters: Record<string, unknown>;
   category: string;
+  access?: ProxyToolAccess;
+  kind?: ProxyToolKind;
+  riskLevel?: ProxyToolRiskLevel;
+  requiresApproval?: boolean;
+  modeAvailability?: ProxyToolModeAvailability[];
+  permissionRuleKey?: string;
   aiEnabled?: boolean;
   handler: (args: Record<string, unknown>) => Promise<string>;
 }
@@ -24,6 +35,12 @@ interface ProxyToolDescriptor {
   description: string;
   parameters: Record<string, unknown>;
   category: string;
+  access?: ProxyToolAccess;
+  kind?: ProxyToolKind;
+  riskLevel?: ProxyToolRiskLevel;
+  requiresApproval?: boolean;
+  modeAvailability?: ProxyToolModeAvailability[];
+  permissionRuleKey?: string;
   aiEnabled?: boolean;
 }
 
@@ -34,4 +51,13 @@ interface AiProxyToolRegistry {
   subscribe(listener: () => void): Disposer;
 }
 
-export type { AiProxyToolRegistry, ProxyToolCallPayload, ProxyToolDescriptor, ProxyToolSpec };
+export type {
+  AiProxyToolRegistry,
+  ProxyToolAccess,
+  ProxyToolCallPayload,
+  ProxyToolDescriptor,
+  ProxyToolKind,
+  ProxyToolModeAvailability,
+  ProxyToolRiskLevel,
+  ProxyToolSpec,
+};

--- a/apps/desktop/src/plugins/builtin/graph_view/index.ts
+++ b/apps/desktop/src/plugins/builtin/graph_view/index.ts
@@ -141,6 +141,12 @@ const graphViewPlugin: KukuPlugin = {
           toolId: `${ctx.pluginId}.find_related_notes`,
           description: "Find notes directly linked to a given note path using the graph index",
           category: "graph",
+          access: "readOnly",
+          kind: "read",
+          riskLevel: "low",
+          requiresApproval: false,
+          modeAvailability: ["ask", "inline", "agent"],
+          permissionRuleKey: `${ctx.pluginId}.find_related_notes`,
           parameters: {
             type: "object",
             properties: {
@@ -174,6 +180,12 @@ const graphViewPlugin: KukuPlugin = {
           toolId: `${ctx.pluginId}.find_orphan_notes`,
           description: "Find notes with no or very few connections. Useful for graph cleanup.",
           category: "graph",
+          access: "readOnly",
+          kind: "search",
+          riskLevel: "low",
+          requiresApproval: false,
+          modeAvailability: ["ask", "inline", "agent"],
+          permissionRuleKey: `${ctx.pluginId}.find_orphan_notes`,
           parameters: {
             type: "object",
             properties: {
@@ -191,6 +203,12 @@ const graphViewPlugin: KukuPlugin = {
           toolId: `${ctx.pluginId}.get_vault_stats`,
           description: "Get vault health statistics: note count, link count, unlinked note count.",
           category: "graph",
+          access: "readOnly",
+          kind: "read",
+          riskLevel: "low",
+          requiresApproval: false,
+          modeAvailability: ["ask", "inline", "agent"],
+          permissionRuleKey: `${ctx.pluginId}.get_vault_stats`,
           parameters: {
             type: "object",
             properties: {},
@@ -204,6 +222,12 @@ const graphViewPlugin: KukuPlugin = {
           description:
             "Suggest wiki-link targets for a document based on content similarity and graph proximity.",
           category: "graph",
+          access: "readOnly",
+          kind: "search",
+          riskLevel: "low",
+          requiresApproval: false,
+          modeAvailability: ["ask", "inline", "agent"],
+          permissionRuleKey: `${ctx.pluginId}.suggest_links`,
           parameters: {
             type: "object",
             properties: {

--- a/apps/desktop/src/plugins/builtin/knowledge/ai_tools.test.ts
+++ b/apps/desktop/src/plugins/builtin/knowledge/ai_tools.test.ts
@@ -35,6 +35,38 @@ describe("knowledge AI tools", () => {
     }
   });
 
+  it("classifies committed Knowledge reads as read-only and proposals as mutations", () => {
+    const registry = createRegistry();
+    const service = createService();
+
+    registerKnowledgeAiTools(registry, service);
+
+    const byName = new Map(registry.list().map((tool) => [tool.name, tool]));
+    for (const name of ["memory_search", "wiki_search", "knowledge_context"]) {
+      expect(byName.get(name)).toMatchObject({
+        access: "readOnly",
+        kind: "search",
+        riskLevel: "low",
+      });
+    }
+    for (const name of ["memory_context", "wiki_read"]) {
+      expect(byName.get(name)).toMatchObject({
+        access: "readOnly",
+        kind: "read",
+        riskLevel: "low",
+      });
+    }
+    for (const name of ["memory_propose", "wiki_propose_page", "wiki_propose_update"]) {
+      expect(byName.get(name)).toMatchObject({
+        access: "proposesMutation",
+        kind: "proposal",
+        riskLevel: "medium",
+        requiresApproval: true,
+        modeAvailability: ["agent"],
+      });
+    }
+  });
+
   it("calls memory_propose and returns the created decision document", async () => {
     const registry = createRegistry();
     const service = createService();
@@ -392,6 +424,12 @@ function createRegistry(): AiProxyToolRegistry {
         description: tool.description,
         parameters: tool.parameters,
         category: tool.category,
+        access: tool.access,
+        kind: tool.kind,
+        riskLevel: tool.riskLevel,
+        requiresApproval: tool.requiresApproval,
+        modeAvailability: tool.modeAvailability,
+        permissionRuleKey: tool.permissionRuleKey,
         aiEnabled: tool.aiEnabled,
       }));
     },

--- a/apps/desktop/src/plugins/builtin/knowledge/ai_tools.ts
+++ b/apps/desktop/src/plugins/builtin/knowledge/ai_tools.ts
@@ -161,6 +161,12 @@ function registerKnowledgeAiTools(
       toolId: "knowledge.memory_search",
       description: "Search committed Knowledge MemoryItems. This is read-only.",
       category: "knowledge",
+      access: "readOnly",
+      kind: "search",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: "knowledge.memory_search",
       parameters: {
         type: "object",
         properties: {
@@ -184,6 +190,12 @@ function registerKnowledgeAiTools(
       toolId: "knowledge.memory_context",
       description: "Return committed Knowledge memory context for a query. This is read-only.",
       category: "knowledge",
+      access: "readOnly",
+      kind: "read",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: "knowledge.memory_context",
       parameters: {
         type: "object",
         properties: {
@@ -210,6 +222,12 @@ function registerKnowledgeAiTools(
       description:
         "Search committed Knowledge wiki pages. This is read-only and only returns Knowledge/wiki pages.",
       category: "knowledge",
+      access: "readOnly",
+      kind: "search",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: "knowledge.wiki_search",
       parameters: {
         type: "object",
         properties: {
@@ -237,6 +255,12 @@ function registerKnowledgeAiTools(
       toolId: "knowledge.wiki_read",
       description: "Read and parse a committed Knowledge wiki page by path. This is read-only.",
       category: "knowledge",
+      access: "readOnly",
+      kind: "read",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: "knowledge.wiki_read",
       parameters: {
         type: "object",
         properties: {
@@ -261,6 +285,12 @@ function registerKnowledgeAiTools(
       description:
         "Return read-only Knowledge context by combining committed memory and wiki search hits.",
       category: "knowledge",
+      access: "readOnly",
+      kind: "search",
+      riskLevel: "low",
+      requiresApproval: false,
+      modeAvailability: ["ask", "inline", "agent"],
+      permissionRuleKey: "knowledge.knowledge_context",
       parameters: {
         type: "object",
         properties: {
@@ -292,6 +322,12 @@ function registerKnowledgeAiTools(
       description:
         "Create a Knowledge decision document that proposes memories for explicit user review. This never commits memory.",
       category: "knowledge",
+      access: "proposesMutation",
+      kind: "proposal",
+      riskLevel: "medium",
+      requiresApproval: true,
+      modeAvailability: ["agent"],
+      permissionRuleKey: "knowledge.memory_propose",
       parameters: {
         type: "object",
         properties: {
@@ -328,6 +364,12 @@ function registerKnowledgeAiTools(
       description:
         "Create a Knowledge decision document that proposes committed wiki pages for explicit user review. This never writes Knowledge/wiki pages.",
       category: "knowledge",
+      access: "proposesMutation",
+      kind: "proposal",
+      riskLevel: "medium",
+      requiresApproval: true,
+      modeAvailability: ["agent"],
+      permissionRuleKey: "knowledge.wiki_propose_page",
       parameters: {
         type: "object",
         properties: {
@@ -364,6 +406,12 @@ function registerKnowledgeAiTools(
       description:
         "Create a Knowledge decision document that proposes updates to existing committed wiki pages. This never applies the update.",
       category: "knowledge",
+      access: "proposesMutation",
+      kind: "proposal",
+      riskLevel: "medium",
+      requiresApproval: true,
+      modeAvailability: ["agent"],
+      permissionRuleKey: "knowledge.wiki_propose_update",
       parameters: {
         type: "object",
         properties: {

--- a/crates/kuku-ai/src/commands.rs
+++ b/crates/kuku-ai/src/commands.rs
@@ -95,8 +95,9 @@ pub async fn ai_register_proxy_tool(
     state: State<'_, AiState>,
     descriptor: ProxyToolDescriptor,
 ) -> Result<(), String> {
-    state.register_proxy_tool(descriptor);
-    Ok(())
+    state
+        .register_proxy_tool(descriptor)
+        .map_err(|error| error.to_string())
 }
 
 #[command]

--- a/crates/kuku-ai/src/lib.rs
+++ b/crates/kuku-ai/src/lib.rs
@@ -22,7 +22,7 @@ use tauri::{
 };
 pub use tools::{
     AiNativeTool, NativeToolResult, ProxyToolDescriptor, ProxyToolResult, ToolAccess,
-    ToolCallContext, ToolDescriptor, ToolSource,
+    ToolCallContext, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource,
 };
 pub use types::{
     AiConfig, ChatMode, EditorContext, EmbeddedFileContext, FinishReason, ModelToolCall,

--- a/crates/kuku-ai/src/session.rs
+++ b/crates/kuku-ai/src/session.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::{
     AiError,
-    mutation::{MutationApplyResult, MutationOp},
+    mutation::{MutationApplyResult, MutationOp, MutationPlan},
     prompts::build_system_prompt,
     provider::{CompletionEvent, CompletionTurnRequest},
     state::AiState,
@@ -441,7 +441,7 @@ async fn handle_tool_call(
                 }
             }
             ToolSource::Proxy => {
-                match execute_proxy_tool(app, state, session, cancel, tool_call, &tool_id).await {
+                match execute_proxy_tool(app, state, session, cancel, tool_call, descriptor).await {
                     Ok(outcome) => outcome,
                     Err(AiError::Cancelled) => return Err(AiError::Cancelled),
                     Err(error) => (error.to_string(), true),
@@ -1100,13 +1100,43 @@ async fn execute_proxy_tool(
     session: &Arc<SessionRuntime>,
     cancel: &CancellationToken,
     tool_call: &ModelToolCall,
-    tool_id: &str,
+    descriptor: ToolDescriptor,
 ) -> Result<(String, bool), AiError> {
+    let tool_id = descriptor.tool_id.clone();
     if state.tools().get_proxy(&tool_call.tool_name).is_none() {
         return Ok((
             format!("Proxy tool {} is not registered", tool_call.tool_name),
             true,
         ));
+    }
+
+    if descriptor.requires_approval {
+        let approval_rx = session.begin_awaiting_approval(tool_call.call_id.clone())?;
+        emit_pending_approval(
+            app,
+            &session.id,
+            &tool_call.call_id,
+            &tool_id,
+            &tool_call.tool_name,
+            proxy_execution_approval_plan(&tool_call.tool_name),
+            Some(format!(
+                "Run proxy tool {} before dispatching it to the plugin.",
+                tool_call.tool_name
+            )),
+        );
+
+        let decision = tokio::select! {
+            _ = cancel.cancelled() => {
+                session.clear_approval(&tool_call.call_id);
+                return Err(AiError::Cancelled);
+            }
+            decision = approval_rx => decision.map_err(|_| AiError::ApprovalNotFound)?,
+        };
+
+        session.set_status(SessionStatus::Streaming);
+        if matches!(decision, ApprovalDecision::Reject) {
+            return Ok(("Rejected by user".to_string(), true));
+        }
     }
 
     let receiver = state
@@ -1116,7 +1146,7 @@ async fn execute_proxy_tool(
         app,
         &session.id,
         &tool_call.call_id,
-        tool_id,
+        &tool_id,
         &tool_call.tool_name,
         tool_call.arguments.clone(),
     );
@@ -1139,6 +1169,13 @@ async fn execute_proxy_tool(
     };
 
     Ok((response.output, response.is_error))
+}
+
+fn proxy_execution_approval_plan(tool_name: &str) -> MutationPlan {
+    MutationPlan {
+        summary: format!("Run proxy tool {tool_name} after user approval."),
+        operations: Vec::new(),
+    }
 }
 
 fn describe_apply_result(result: &MutationApplyResult) -> String {
@@ -1330,8 +1367,8 @@ fn empty_directory_checksum() -> String {
 mod tests {
     use super::{
         SessionRuntime, SessionStatus, compact_history_for_model, content_with_mode_notice,
-        content_with_turn_context, remember_embedded_file_snapshots, summarize_output,
-        tool_not_allowed_message,
+        content_with_turn_context, proxy_execution_approval_plan, remember_embedded_file_snapshots,
+        summarize_output, tool_not_allowed_message,
     };
     use crate::types::{ChatMessage, ChatMode, EditorContext, EmbeddedFileContext};
 
@@ -1494,6 +1531,14 @@ mod tests {
             tool_not_allowed_message("edit_file", &ChatMode::Ask),
             "Tool 'edit_file' is not available in Ask mode for this turn."
         );
+    }
+
+    #[test]
+    fn proxy_execution_approval_plan_describes_pre_execution_approval_without_file_ops() {
+        let plan = proxy_execution_approval_plan("memory_propose");
+
+        assert!(plan.summary.contains("Run proxy tool memory_propose"));
+        assert!(plan.operations.is_empty());
     }
 
     #[test]

--- a/crates/kuku-ai/src/state.rs
+++ b/crates/kuku-ai/src/state.rs
@@ -96,8 +96,8 @@ impl AiState {
         self.inner.tools.register_native(tool);
     }
 
-    pub fn register_proxy_tool(&self, descriptor: ProxyToolDescriptor) {
-        self.inner.tools.register_proxy(descriptor);
+    pub fn register_proxy_tool(&self, descriptor: ProxyToolDescriptor) -> Result<(), AiError> {
+        self.inner.tools.register_proxy(descriptor)
     }
 
     pub fn remember_path_snapshot(

--- a/crates/kuku-ai/src/tools/descriptor.rs
+++ b/crates/kuku-ai/src/tools/descriptor.rs
@@ -97,9 +97,7 @@ pub fn allowed_tools(mode: ChatMode, descriptors: &[ToolDescriptor]) -> Vec<Tool
 mod tests {
     use serde_json::json;
 
-    use super::{
-        ToolAccess, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource, allowed_tools,
-    };
+    use super::{ToolAccess, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource, allowed_tools};
     use crate::types::ChatMode;
 
     fn tool(name: &str, tool_id: &str, access: ToolAccess) -> ToolDescriptor {

--- a/crates/kuku-ai/src/tools/descriptor.rs
+++ b/crates/kuku-ai/src/tools/descriptor.rs
@@ -75,18 +75,25 @@ pub struct ToolDescriptor {
 
 pub fn allowed_tools(mode: ChatMode, descriptors: &[ToolDescriptor]) -> Vec<ToolDescriptor> {
     match mode {
-        ChatMode::Agent => descriptors.to_vec(),
+        ChatMode::Agent => descriptors
+            .iter()
+            .filter(|tool| tool.mode_availability.contains(&mode))
+            .cloned()
+            .collect(),
         ChatMode::Ask => descriptors
             .iter()
-            .filter(|tool| tool.access == ToolAccess::ReadOnly)
+            .filter(|tool| {
+                tool.mode_availability.contains(&mode) && tool.access == ToolAccess::ReadOnly
+            })
             .cloned()
             .collect(),
         ChatMode::Inline => descriptors
             .iter()
             .filter(|tool| {
-                tool.access == ToolAccess::ReadOnly
-                    || tool.tool_id == INLINE_EDIT_TOOL_ID
-                    || tool.name == "edit_file"
+                tool.mode_availability.contains(&mode)
+                    && (tool.access == ToolAccess::ReadOnly
+                        || tool.tool_id == INLINE_EDIT_TOOL_ID
+                        || tool.name == "edit_file")
             })
             .cloned()
             .collect(),
@@ -101,6 +108,20 @@ mod tests {
     use crate::types::ChatMode;
 
     fn tool(name: &str, tool_id: &str, access: ToolAccess) -> ToolDescriptor {
+        tool_with_modes(
+            name,
+            tool_id,
+            access,
+            vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent],
+        )
+    }
+
+    fn tool_with_modes(
+        name: &str,
+        tool_id: &str,
+        access: ToolAccess,
+        mode_availability: Vec<ChatMode>,
+    ) -> ToolDescriptor {
         ToolDescriptor {
             tool_id: tool_id.to_string(),
             name: name.to_string(),
@@ -110,7 +131,7 @@ mod tests {
             kind: ToolKind::Other,
             requires_approval: access == ToolAccess::ProposesMutation,
             risk_level: ToolRiskLevel::Low,
-            mode_availability: Vec::new(),
+            mode_availability,
             permission_rule_key: tool_id.to_string(),
             access,
             source: ToolSource::Native,
@@ -160,5 +181,19 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(names, vec!["read_file"]);
+    }
+
+    #[test]
+    fn mode_availability_limits_tools_within_access_policy() {
+        let tools = vec![tool_with_modes(
+            "agent_only_read",
+            "builtin.agent_only_read",
+            ToolAccess::ReadOnly,
+            vec![ChatMode::Agent],
+        )];
+
+        assert!(allowed_tools(ChatMode::Ask, &tools).is_empty());
+        assert!(allowed_tools(ChatMode::Inline, &tools).is_empty());
+        assert_eq!(allowed_tools(ChatMode::Agent, &tools).len(), 1);
     }
 }

--- a/crates/kuku-ai/src/tools/descriptor.rs
+++ b/crates/kuku-ai/src/tools/descriptor.rs
@@ -12,11 +12,42 @@ pub enum ToolAccess {
     ProposesMutation,
 }
 
+fn default_tool_access() -> ToolAccess {
+    ToolAccess::ReadOnly
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ToolSource {
     Native,
     Proxy,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ToolKind {
+    Read,
+    Search,
+    Edit,
+    Proposal,
+    Navigation,
+    Other,
+}
+
+fn default_tool_kind() -> ToolKind {
+    ToolKind::Other
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ToolRiskLevel {
+    Low,
+    Medium,
+    High,
+}
+
+fn default_tool_risk_level() -> ToolRiskLevel {
+    ToolRiskLevel::Low
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,6 +58,17 @@ pub struct ToolDescriptor {
     pub description: String,
     pub parameters: Value,
     pub category: String,
+    #[serde(default = "default_tool_kind")]
+    pub kind: ToolKind,
+    #[serde(default)]
+    pub requires_approval: bool,
+    #[serde(default = "default_tool_risk_level")]
+    pub risk_level: ToolRiskLevel,
+    #[serde(default)]
+    pub mode_availability: Vec<ChatMode>,
+    #[serde(default)]
+    pub permission_rule_key: String,
+    #[serde(default = "default_tool_access")]
     pub access: ToolAccess,
     pub source: ToolSource,
 }
@@ -55,7 +97,9 @@ pub fn allowed_tools(mode: ChatMode, descriptors: &[ToolDescriptor]) -> Vec<Tool
 mod tests {
     use serde_json::json;
 
-    use super::{ToolAccess, ToolDescriptor, ToolSource, allowed_tools};
+    use super::{
+        ToolAccess, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource, allowed_tools,
+    };
     use crate::types::ChatMode;
 
     fn tool(name: &str, tool_id: &str, access: ToolAccess) -> ToolDescriptor {
@@ -65,6 +109,11 @@ mod tests {
             description: format!("{name} tool"),
             parameters: json!({}),
             category: "test".to_string(),
+            kind: ToolKind::Other,
+            requires_approval: access == ToolAccess::ProposesMutation,
+            risk_level: ToolRiskLevel::Low,
+            mode_availability: Vec::new(),
+            permission_rule_key: tool_id.to_string(),
             access,
             source: ToolSource::Native,
         }

--- a/crates/kuku-ai/src/tools/mod.rs
+++ b/crates/kuku-ai/src/tools/mod.rs
@@ -31,10 +31,12 @@ impl ToolRegistry {
         self.native.read().get(name).cloned()
     }
 
-    pub fn register_proxy(&self, descriptor: ProxyToolDescriptor) {
+    pub fn register_proxy(&self, descriptor: ProxyToolDescriptor) -> Result<(), crate::AiError> {
+        descriptor.validate()?;
         self.proxy
             .write()
             .insert(descriptor.name.clone(), descriptor);
+        Ok(())
     }
 
     pub fn unregister_proxy(&self, name: &str) {

--- a/crates/kuku-ai/src/tools/mod.rs
+++ b/crates/kuku-ai/src/tools/mod.rs
@@ -8,7 +8,9 @@ use std::{collections::HashMap, sync::Arc};
 use parking_lot::RwLock;
 
 pub use context::ToolCallContext;
-pub use descriptor::{ToolAccess, ToolDescriptor, ToolSource, allowed_tools};
+pub use descriptor::{
+    ToolAccess, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource, allowed_tools,
+};
 pub use native::{AiNativeTool, NativeToolResult};
 pub use proxy::{ProxyBroker, ProxyToolDescriptor, ProxyToolResult};
 

--- a/crates/kuku-ai/src/tools/proxy.rs
+++ b/crates/kuku-ai/src/tools/proxy.rs
@@ -7,7 +7,8 @@ use tokio::sync::oneshot;
 
 use crate::{
     AiError,
-    tools::{ToolAccess, ToolDescriptor, ToolSource},
+    tools::{ToolAccess, ToolDescriptor, ToolKind, ToolRiskLevel, ToolSource},
+    types::ChatMode,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,6 +19,18 @@ pub struct ProxyToolDescriptor {
     pub description: String,
     pub parameters: Value,
     pub category: String,
+    #[serde(default)]
+    pub kind: Option<ToolKind>,
+    #[serde(default)]
+    pub requires_approval: Option<bool>,
+    #[serde(default)]
+    pub risk_level: Option<ToolRiskLevel>,
+    #[serde(default)]
+    pub mode_availability: Option<Vec<ChatMode>>,
+    #[serde(default)]
+    pub permission_rule_key: Option<String>,
+    #[serde(default)]
+    pub access: Option<ToolAccess>,
 }
 
 impl ProxyToolDescriptor {
@@ -28,7 +41,15 @@ impl ProxyToolDescriptor {
             description: self.description.clone(),
             parameters: self.parameters.clone(),
             category: self.category.clone(),
-            access: ToolAccess::ReadOnly,
+            kind: self.kind.clone().unwrap_or(ToolKind::Other),
+            requires_approval: self.requires_approval.unwrap_or(false),
+            risk_level: self.risk_level.clone().unwrap_or(ToolRiskLevel::Low),
+            mode_availability: self.mode_availability.clone().unwrap_or_default(),
+            permission_rule_key: self
+                .permission_rule_key
+                .clone()
+                .unwrap_or_else(|| self.tool_id.clone()),
+            access: self.access.clone().unwrap_or(ToolAccess::ReadOnly),
             source: ToolSource::Proxy,
         }
     }
@@ -66,5 +87,48 @@ impl ProxyBroker {
 
     pub fn clear(&self, call_id: &str) {
         self.pending.lock().remove(call_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::ProxyToolDescriptor;
+    use crate::{tools::allowed_tools, types::ChatMode, ToolAccess};
+
+    #[test]
+    fn proxy_descriptor_preserves_explicit_proposes_mutation_access() {
+        let descriptor: ProxyToolDescriptor = serde_json::from_value(json!({
+            "toolId": "knowledge.memory_propose",
+            "name": "memory_propose",
+            "description": "Create a Knowledge decision document for review.",
+            "parameters": { "type": "object", "properties": {} },
+            "category": "knowledge",
+            "access": "proposesMutation"
+        }))
+        .expect("proxy descriptor should deserialize");
+
+        let tool = descriptor.as_tool_descriptor();
+
+        assert_eq!(tool.access, ToolAccess::ProposesMutation);
+    }
+
+    #[test]
+    fn proxy_proposal_tools_are_not_available_in_ask_or_inline_modes() {
+        let descriptor: ProxyToolDescriptor = serde_json::from_value(json!({
+            "toolId": "knowledge.wiki_propose_page",
+            "name": "wiki_propose_page",
+            "description": "Create a Knowledge decision document for review.",
+            "parameters": { "type": "object", "properties": {} },
+            "category": "knowledge",
+            "access": "proposesMutation"
+        }))
+        .expect("proxy descriptor should deserialize");
+        let tools = vec![descriptor.as_tool_descriptor()];
+
+        assert!(allowed_tools(ChatMode::Ask, &tools).is_empty());
+        assert!(allowed_tools(ChatMode::Inline, &tools).is_empty());
+        assert_eq!(allowed_tools(ChatMode::Agent, &tools).len(), 1);
     }
 }

--- a/crates/kuku-ai/src/tools/proxy.rs
+++ b/crates/kuku-ai/src/tools/proxy.rs
@@ -95,7 +95,7 @@ mod tests {
     use serde_json::json;
 
     use super::ProxyToolDescriptor;
-    use crate::{tools::allowed_tools, types::ChatMode, ToolAccess};
+    use crate::{ToolAccess, tools::allowed_tools, types::ChatMode};
 
     #[test]
     fn proxy_descriptor_preserves_explicit_proposes_mutation_access() {

--- a/crates/kuku-ai/src/tools/proxy.rs
+++ b/crates/kuku-ai/src/tools/proxy.rs
@@ -34,7 +34,17 @@ pub struct ProxyToolDescriptor {
 }
 
 impl ProxyToolDescriptor {
+    pub fn validate(&self) -> Result<(), AiError> {
+        if matches!(self.mode_availability.as_ref(), Some(modes) if modes.is_empty()) {
+            return Err(AiError::InvalidArguments(
+                "Proxy tool modeAvailability must contain at least one chat mode".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn as_tool_descriptor(&self) -> ToolDescriptor {
+        let access = self.access.clone().unwrap_or(ToolAccess::ReadOnly);
         ToolDescriptor {
             tool_id: self.tool_id.clone(),
             name: self.name.clone(),
@@ -44,14 +54,24 @@ impl ProxyToolDescriptor {
             kind: self.kind.clone().unwrap_or(ToolKind::Other),
             requires_approval: self.requires_approval.unwrap_or(false),
             risk_level: self.risk_level.clone().unwrap_or(ToolRiskLevel::Low),
-            mode_availability: self.mode_availability.clone().unwrap_or_default(),
+            mode_availability: self
+                .mode_availability
+                .clone()
+                .unwrap_or_else(|| default_mode_availability_for_access(&access)),
             permission_rule_key: self
                 .permission_rule_key
                 .clone()
                 .unwrap_or_else(|| self.tool_id.clone()),
-            access: self.access.clone().unwrap_or(ToolAccess::ReadOnly),
+            access,
             source: ToolSource::Proxy,
         }
+    }
+}
+
+fn default_mode_availability_for_access(access: &ToolAccess) -> Vec<ChatMode> {
+    match access {
+        ToolAccess::ReadOnly => vec![ChatMode::Ask, ChatMode::Inline, ChatMode::Agent],
+        ToolAccess::ProposesMutation => vec![ChatMode::Agent],
     }
 }
 
@@ -112,6 +132,42 @@ mod tests {
         let tool = descriptor.as_tool_descriptor();
 
         assert_eq!(tool.access, ToolAccess::ProposesMutation);
+    }
+
+    #[test]
+    fn proxy_descriptor_rejects_empty_mode_availability() {
+        let descriptor: ProxyToolDescriptor = serde_json::from_value(json!({
+            "toolId": "knowledge.memory_context",
+            "name": "memory_context",
+            "description": "Read committed Knowledge memory.",
+            "parameters": { "type": "object", "properties": {} },
+            "category": "knowledge",
+            "modeAvailability": []
+        }))
+        .expect("proxy descriptor should deserialize");
+
+        let error = descriptor
+            .validate()
+            .expect_err("empty modes should be invalid");
+
+        assert!(error.to_string().contains("modeAvailability"));
+    }
+
+    #[test]
+    fn proxy_descriptor_defaults_missing_mode_availability_from_access() {
+        let descriptor: ProxyToolDescriptor = serde_json::from_value(json!({
+            "toolId": "knowledge.wiki_propose_update",
+            "name": "wiki_propose_update",
+            "description": "Create a Knowledge decision document for review.",
+            "parameters": { "type": "object", "properties": {} },
+            "category": "knowledge",
+            "access": "proposesMutation"
+        }))
+        .expect("proxy descriptor should deserialize");
+
+        let tool = descriptor.as_tool_descriptor();
+
+        assert_eq!(tool.mode_availability, vec![ChatMode::Agent]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add shared AI tool permission metadata for native and proxy tools.
- Preserve proxy tool metadata through the desktop registry and Rust bridge.
- Treat knowledge proposal proxy tools as Agent-only mutation proposals with pre-execution approval.
- Enforce mode availability in tool filtering and reject explicitly empty proxy mode availability.
- Clear stale Rust proxy descriptors when proxy registration fails.

## Production readiness review
- `origin/develop` is an ancestor of this branch and the branch is 5 commits ahead.
- The working tree is clean.
- No new blocking review findings remain from the local review pass.
- The change is scoped to tool descriptors, tool filtering, proxy registration metadata, and approval behavior.
- Remaining product/UI wording work, such as differentiating "executed" from "applied" for proxy proposal approvals, can be handled separately.

## Validation
- `git diff --check origin/develop...HEAD`
- `cargo fmt -p kuku-ai -- --check`
- `cargo fmt -p kuku-app -- --check`
- `cargo test -p kuku-ai`
- `cargo test -p kuku-app`
- `pnpm --dir apps/desktop exec tsc --noEmit`
- `pnpm --dir apps/desktop exec vitest run`
