### PR TITLE
[codex] Polish chat panel scrolling

### DIFF
--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_panel.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_panel.tsx
@@ -219,7 +219,8 @@ function ChatPanel(): JSX.Element {
       return;
     }
     const last = session.messages[session.messages.length - 1];
-    if (last.kind === "text" && last.role === "user") {
+    const awaitingResponse = session.status === "streaming" || session.status === "applying";
+    if (last.kind === "text" && last.role === "user" && !awaitingResponse) {
       revealLatestUserToView();
     } else {
       scrollToBottom("smooth");
@@ -267,6 +268,7 @@ function ChatPanel(): JSX.Element {
         const session = activeId ? (chatState.sessions[activeId] ?? null) : null;
         const count = session?.messages.length ?? 0;
         const last = count > 0 && session ? session.messages[count - 1] : null;
+        const status = session?.status ?? "idle";
         let hasFirstToken = false;
         let lastStreaming = false;
         let streamChunk = 0;
@@ -278,7 +280,7 @@ function ChatPanel(): JSX.Element {
             streamChunk = Math.floor(last.content.length / 96);
           }
         }
-        return `${activeId ?? ""}|${count}|${last?.id ?? ""}|${lastStreaming}|${hasFirstToken}|${streamChunk}`;
+        return `${activeId ?? ""}|${status}|${count}|${last?.id ?? ""}|${lastStreaming}|${hasFirstToken}|${streamChunk}`;
       },
       () => {
         const activeId = chatState.activeSessionId;
@@ -325,6 +327,11 @@ function ChatPanel(): JSX.Element {
             }}
             onViewportReady={() => {
               scheduleAutoscroll();
+            }}
+            onLayout={(_, reason) => {
+              if (reason === "content" || reason === "resize") {
+                scheduleAutoscroll();
+              }
             }}
             onScroll={() => {
               handleScroll();

--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_panel.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_panel.tsx
@@ -181,6 +181,12 @@ function ChatPanel(): JSX.Element {
     return position.scrollHeight - position.top - position.height < threshold;
   }
 
+  function isAwaitingResponse(): boolean {
+    const activeId = chatState.activeSessionId;
+    const session = activeId ? (chatState.sessions[activeId] ?? null) : null;
+    return session?.status === "streaming" || session?.status === "applying";
+  }
+
   function scrollToBottom(behavior: ScrollBehavior = "smooth"): void {
     if (!scrollHandle) return;
     // Smooth scroll emits many onScrolls; do not let them clear "follow" mid-animation.
@@ -219,8 +225,7 @@ function ChatPanel(): JSX.Element {
       return;
     }
     const last = session.messages[session.messages.length - 1];
-    const awaitingResponse = session.status === "streaming" || session.status === "applying";
-    if (last.kind === "text" && last.role === "user" && !awaitingResponse) {
+    if (last.kind === "text" && last.role === "user" && !isAwaitingResponse()) {
       revealLatestUserToView();
     } else {
       scrollToBottom("smooth");
@@ -257,6 +262,16 @@ function ChatPanel(): JSX.Element {
     if (userScrolledAway) {
       cancelPendingAutoscroll();
     }
+  }
+
+  function handleWheel(event: WheelEvent): void {
+    if (event.deltaY >= 0 || !scrollHandle) return;
+    const position = scrollHandle.getScrollPosition();
+    if (position.top <= 0 || position.scrollHeight <= position.height) return;
+    ignoreScrollEvents = 0;
+    userScrolledAway = true;
+    cancelPendingAutoscroll();
+    scrollHandle.scrollTo({ top: position.top, behavior: "auto" });
   }
 
   // Structural + coarser streaming: last message is user → reveal; assistant reply → follow bottom (bucketed).
@@ -329,12 +344,15 @@ function ChatPanel(): JSX.Element {
               scheduleAutoscroll();
             }}
             onLayout={(_, reason) => {
-              if (reason === "content" || reason === "resize") {
+              if (reason === "resize" || (reason === "content" && !isAwaitingResponse())) {
                 scheduleAutoscroll();
               }
             }}
             onScroll={() => {
               handleScroll();
+            }}
+            onWheel={(event) => {
+              handleWheel(event);
             }}
           >
             <ChatMessages />

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/chat_messages.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/chat_messages.tsx
@@ -351,7 +351,7 @@ function ChatMessages(): JSX.Element {
   }
 
   return (
-    <div class="flex min-h-full min-w-0 flex-col px-3 pt-4 pb-2.5">
+    <div class="flex min-h-full min-w-0 flex-col px-3 pt-4 pb-9">
       <Show
         when={hasMessages()}
         fallback={<ChatWelcome mode={chatState.selectedMode} onSubmit={handleWelcomeSubmit} />}

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
@@ -77,9 +77,7 @@ function ChatWelcome(props: ChatWelcomeProps): JSX.Element {
                       <span class="text-[0.8125rem]/5 font-medium text-text-primary">
                         {t(item.text)}
                       </span>
-                      <span class="text-[0.71875rem]/4 text-text-muted">
-                        {t(item.hint)}
-                      </span>
+                      <span class="text-[0.71875rem]/4 text-text-muted">{t(item.hint)}</span>
                     </button>
                   </li>
                 )}

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
@@ -61,21 +61,23 @@ function ChatWelcome(props: ChatWelcomeProps): JSX.Element {
         </header>
 
         <div>
-          <p class="mb-2.5 pl-0.5 text-[0.625rem] font-semibold tracking-[0.18em] text-text-muted uppercase">
+          <p class="mb-2 pl-0.5 text-[0.625rem] font-semibold tracking-[0.16em] text-text-muted uppercase">
             {t("chat.welcome.try_asking")}
           </p>
-          <div class="overflow-hidden rounded-lg border border-border/80 bg-bg-secondary/40">
-            <ul class="divide-y divide-border/70">
+          <div class="overflow-hidden rounded-md border border-border/60 bg-bg-secondary/25">
+            <ul class="divide-y divide-border/50">
               <For each={SUGGESTED_PROMPTS}>
                 {(item) => (
                   <li>
                     <button
                       type="button"
-                      class="group flex w-full flex-col items-start gap-0.5 px-4 py-3.5 text-left transition hover:bg-ghost-hover active:bg-ghost-active"
+                      class="group flex w-full flex-col items-start gap-px px-3.5 py-2.5 text-left transition hover:bg-ghost-hover active:bg-ghost-active"
                       onClick={() => props.onSubmit(item.mode, item.prompt)}
                     >
-                      <span class="text-sm font-medium text-text-primary">{t(item.text)}</span>
-                      <span class="text-xs/snug text-text-muted">{t(item.hint)}</span>
+                      <span class="text-[0.8125rem] leading-5 font-medium text-text-primary">
+                        {t(item.text)}
+                      </span>
+                      <span class="text-[0.71875rem] leading-4 text-text-muted">{t(item.hint)}</span>
                     </button>
                   </li>
                 )}

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/chat_welcome.tsx
@@ -74,10 +74,12 @@ function ChatWelcome(props: ChatWelcomeProps): JSX.Element {
                       class="group flex w-full flex-col items-start gap-px px-3.5 py-2.5 text-left transition hover:bg-ghost-hover active:bg-ghost-active"
                       onClick={() => props.onSubmit(item.mode, item.prompt)}
                     >
-                      <span class="text-[0.8125rem] leading-5 font-medium text-text-primary">
+                      <span class="text-[0.8125rem]/5 font-medium text-text-primary">
                         {t(item.text)}
                       </span>
-                      <span class="text-[0.71875rem] leading-4 text-text-muted">{t(item.hint)}</span>
+                      <span class="text-[0.71875rem]/4 text-text-muted">
+                        {t(item.hint)}
+                      </span>
                     </button>
                   </li>
                 )}


### PR DESCRIPTION
## Summary
- tighten the AI chat welcome prompt cards so the desktop panel feels less tall and more polished
- keep the chat transcript pinned to the response/thinking area when long user messages are sent
- add bottom breathing room so the auto-approve tab does not cover the latest chat state

## Why
Long prompts could leave the panel scrolled to the top of the user message while Thinking or the assistant response was below the visible area. The auto-approve tab also overlapped the transcript bottom.

## Validation
- pnpm --filter @kuku/desktop build

Note: Vite still reports the existing large chunk warning.