### PR TITLE
feat: persist chat sessions by vault

### DIFF
--- a/apps/desktop/src/app.tsx
+++ b/apps/desktop/src/app.tsx
@@ -217,7 +217,7 @@ export default function App() {
             style={{ ...DRAG, "grid-template-columns": titleBarGridTemplateColumns() }}
           >
             <div
-              class="relative flex h-full items-center justify-end bg-bg-secondary px-1"
+              class="relative flex h-full items-center justify-end border-r border-border bg-bg-secondary px-1"
               data-kuku-titlebar-left-toggle-cell="true"
               data-tauri-drag-region
             >
@@ -238,7 +238,7 @@ export default function App() {
                 <PanelLeftIcon active={layoutState.leftPanelOpen} />
               </button>
             </div>
-            <div class="flex h-full min-w-0">
+            <div class="flex h-full min-w-0" classList={{ "pr-8": !layoutState.rightPanelOpen }}>
               <TabBar />
             </div>
             <Show when={layoutState.rightPanelOpen}>

--- a/apps/desktop/src/components/layout/title_bar.tsx
+++ b/apps/desktop/src/components/layout/title_bar.tsx
@@ -87,7 +87,7 @@ export default function TitleBar(props: TitleBarProps) {
 
       {/* ── Right region ── */}
       <div
-        class="absolute inset-y-0 right-0 z-20 flex items-center justify-end px-1"
+        class="absolute inset-y-0 right-0 z-20 flex items-center justify-end bg-bg-secondary px-1"
         style={DRAG}
         data-kuku-titlebar-right-hit-area="true"
         data-tauri-drag-region

--- a/apps/desktop/src/components/layout/title_bar_composition.test.ts
+++ b/apps/desktop/src/components/layout/title_bar_composition.test.ts
@@ -37,7 +37,7 @@ describe("title bar composition", () => {
     expect(appSource).toContain('data-kuku-titlebar-left-toggle-cell="true"');
     expect(appSource).not.toContain('data-kuku-titlebar-right-toggle-cell="true"');
     expect(appSource).toContain(
-      'class="relative flex h-full items-center justify-end bg-bg-secondary px-1"',
+      'class="relative flex h-full items-center justify-end border-r border-border bg-bg-secondary px-1"',
     );
 
     const leftToggleIndex = appSource.indexOf('data-kuku-titlebar-left-toggle-cell="true"');
@@ -58,14 +58,38 @@ describe("title bar composition", () => {
     expect(titleBarSource).toContain(
       'class="absolute inset-0 z-10 flex h-full min-w-0 items-stretch"',
     );
+    expect(titleBarSource).not.toContain("items-stretch pr-8");
     expect(titleBarSource).toContain(
       'class="absolute inset-y-0 left-0 z-20 flex items-center px-1"',
     );
     expect(titleBarSource).toContain(
-      'class="absolute inset-y-0 right-0 z-20 flex items-center justify-end px-1"',
+      'class="absolute inset-y-0 right-0 z-20 flex items-center justify-end bg-bg-secondary px-1"',
     );
     expect(titleBarSource).not.toContain("flex min-w-18 items-center justify-end");
     expect(titleBarSource).not.toContain("absolute inset-x-0 flex items-center justify-center");
+  });
+
+  it("gives the right title bar controls an opaque background without a left divider", () => {
+    const titleBarSource = readSource("components/layout/title_bar.tsx");
+
+    expect(titleBarSource).toContain('data-kuku-titlebar-right-hit-area="true"');
+    expect(titleBarSource).toContain(
+      'class="absolute inset-y-0 right-0 z-20 flex items-center justify-end bg-bg-secondary px-1"',
+    );
+    expect(titleBarSource).not.toContain(
+      'right-0 z-20 flex items-center justify-end border-l border-border bg-bg-secondary',
+    );
+  });
+
+  it("reserves right title bar chrome so tab actions stay visible", () => {
+    const appSource = readSource("app.tsx");
+    const tabBarSource = readSource("components/layout/tab_bar.tsx");
+
+    expect(appSource).toContain(
+      'classList={{ "pr-8": !layoutState.rightPanelOpen }}',
+    );
+    expect(appSource).toContain("<RightPanelTabBar />");
+    expect(tabBarSource).toContain('data-kuku-inline-new-tab-button="true"');
   });
 
   it("keeps unused title bar areas draggable", () => {
@@ -76,6 +100,7 @@ describe("title bar composition", () => {
 
     expect(titleBarSource).toContain("const DRAG");
     expect(titleBarSource).toContain('class="absolute inset-0 z-10 flex h-full min-w-0 items-stretch"');
+    expect(titleBarSource).not.toContain("items-stretch pr-8");
     expect(titleBarSource).toContain("style={DRAG}");
     expect(titleBarSource).toContain("data-tauri-drag-region");
     expect(appSource).toContain("const DRAG =");
@@ -184,7 +209,7 @@ describe("title bar composition", () => {
     const tabBarSource = readSource("components/layout/tab_bar.tsx");
 
     expect(appSource).toContain(
-      'class="relative flex h-full items-center justify-end bg-bg-secondary px-1"',
+      'class="relative flex h-full items-center justify-end border-r border-border bg-bg-secondary px-1"',
     );
     expect(appSource).toContain('side="left"');
     expect(tabBarSource).not.toContain("border-l border-border");
@@ -341,6 +366,13 @@ describe("title bar composition", () => {
     expect(tabBarSource).not.toContain("-bottom-px h-px");
     expect(rightPanelTabBarSource).not.toContain("-mb-px");
     expect(rightPanelTabBarSource).not.toContain("-bottom-px h-px");
+  });
+
+  it("does not draw a left divider inside the active tab", () => {
+    const tabBarSource = readSource("components/layout/tab_bar.tsx");
+
+    expect(tabBarSource).not.toContain('data-kuku-active-tab-left-divider="true"');
+    expect(tabBarSource).toContain('data-kuku-active-tab-divider-mask="true"');
   });
 
   it("keeps the title bar height at 34px", () => {

--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_store.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_store.test.ts
@@ -1092,6 +1092,91 @@ describe("ai_chat chat_store session modes", () => {
     ]);
   });
 
+  it("starts a fresh ACP session when a restored legacy session has no external id", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Notes");
+    localStorage.setItem(
+      scopedChatSessionsStorageKey("/Users/me/Notes"),
+      JSON.stringify({
+        version: 1,
+        sessions: [
+          {
+            id: "legacy-acp-session",
+            externalSessionId: null,
+            agentId: "codex-acp",
+            mode: "ask",
+            createdAt: 1_699_999,
+            updatedAt: 1_700_001,
+            persistedTitle: "Legacy Codex session",
+            supportsLoad: true,
+            supportsResume: true,
+            draft: "",
+            autoApprove: false,
+            messages: [
+              {
+                id: "message-1",
+                kind: "text",
+                role: "user",
+                content: "old prompt",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "plugin:kuku-ai|ai_list_sessions":
+          return [];
+        case "plugin:kuku-ai|ai_new_session":
+          return { sessionId: "fresh-acp-session" };
+        case "plugin:kuku-ai|ai_send_message":
+          return undefined;
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const chat = await loadChatStoreModule();
+    await chat.loadSessions();
+
+    expect(chat.switchSession("legacy-acp-session")).toBe(true);
+    await expect(chat.sendMessage("continue here")).resolves.toBe(true);
+
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "plugin:kuku-ai|ai_restore_session",
+      expect.anything(),
+    );
+    expect(mockInvoke).toHaveBeenCalledWith("plugin:kuku-ai|ai_new_session", {
+      agentId: "codex-acp",
+      mode: "ask",
+      workingDirectory: "/Users/me/Notes",
+    });
+    const sendCall = mockInvoke.mock.calls.find(
+      ([command]) => command === "plugin:kuku-ai|ai_send_message",
+    );
+    expect(sendCall?.[1]).toMatchObject({
+      agentId: "codex-acp",
+      sessionId: "fresh-acp-session",
+    });
+    expect(sendCall?.[1].content).toContain("<previous_transcript>");
+    expect(sendCall?.[1].content).toContain("USER: old prompt");
+    expect(sendCall?.[1].content).toContain("continue here");
+    expect(chat.chatState.sessions["legacy-acp-session"]?.error).toBeNull();
+    expect(chat.chatState.activeSessionId).toBe("fresh-acp-session");
+    expect(chat.chatState.sessions["fresh-acp-session"]?.messages).toMatchObject([
+      {
+        kind: "text",
+        role: "user",
+        content: "old prompt",
+      },
+      {
+        kind: "text",
+        role: "user",
+        content: "continue here",
+      },
+    ]);
+  });
+
   it("exposes the builtin catalog and enables Codex only after loading backend availability", async () => {
     mockInvoke.mockImplementation(async (command: string) => {
       switch (command) {

--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_store.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_store.test.ts
@@ -5,6 +5,8 @@ const mockReadVaultFileWithChecksum = vi.fn();
 const mockContextSnapshot = vi.fn();
 const mockGetCurrentVault = vi.fn();
 const CHAT_SESSIONS_STORAGE_KEY = "kuku.aiChat.sessions.v1";
+const scopedChatSessionsStorageKey = (vaultRoot: string | null) =>
+  `${CHAT_SESSIONS_STORAGE_KEY}:${encodeURIComponent(vaultRoot ?? "no-vault")}`;
 
 class StorageMock {
   private readonly data = new Map<string, string>();
@@ -570,6 +572,7 @@ describe("ai_chat chat_store session modes", () => {
               updatedAtMs: 1_700_000,
               supportsLoad: false,
               supportsResume: true,
+              workingDirectory: "/Users/me/Notes",
             },
           ];
         case "plugin:kuku-ai|ai_restore_session":
@@ -689,7 +692,7 @@ describe("ai_chat chat_store session modes", () => {
 
   it("restores locally saved session messages after app restart", async () => {
     localStorage.setItem(
-      CHAT_SESSIONS_STORAGE_KEY,
+      scopedChatSessionsStorageKey(null),
       JSON.stringify({
         version: 1,
         sessions: [
@@ -763,12 +766,241 @@ describe("ai_chat chat_store session modes", () => {
     });
   });
 
+  it("restores session messages from the backend chat session store", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Notes");
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "plugin:kuku-ai|ai_list_chat_sessions":
+          return [
+            {
+              id: "persisted-1",
+              externalSessionId: "external-1",
+              agentId: "codex-acp",
+              mode: "ask",
+              createdAt: 1_699_999,
+              updatedAt: 1_700_001,
+              persistedTitle: "Summarize workspace",
+              supportsLoad: false,
+              supportsResume: true,
+              workingDirectory: "/Users/me/Notes",
+              draft: "follow up",
+              autoApprove: true,
+              messages: [
+                {
+                  id: "message-1",
+                  kind: "text",
+                  role: "user",
+                  content: "remember this",
+                },
+              ],
+            },
+          ];
+        case "plugin:kuku-ai|ai_list_sessions":
+          return [
+            {
+              localSessionId: "persisted-1",
+              externalSessionId: "external-1",
+              agentId: "codex-acp",
+              title: "Summarize workspace",
+              updatedAtMs: 1_700_000,
+              supportsLoad: false,
+              supportsResume: true,
+              workingDirectory: "/Users/me/Notes",
+            },
+          ];
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const chat = await loadChatStoreModule();
+
+    await chat.loadSessions();
+
+    expect(mockInvoke).toHaveBeenCalledWith("plugin:kuku-ai|ai_list_chat_sessions", {
+      workingDirectory: "/Users/me/Notes",
+    });
+    expect(localStorage.getItem(scopedChatSessionsStorageKey("/Users/me/Notes"))).toBeNull();
+    expect(chat.chatState.activeSessionId).toBe("persisted-1");
+    expect(chat.chatState.sessions["persisted-1"]).toMatchObject({
+      id: "persisted-1",
+      draft: "follow up",
+      autoApprove: true,
+      messages: [
+        {
+          id: "message-1",
+          kind: "text",
+          role: "user",
+          content: "remember this",
+        },
+      ],
+    });
+  });
+
+  it("loads locally saved sessions only for the active vault", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Vault A");
+    localStorage.setItem(
+      CHAT_SESSIONS_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        sessions: [
+          {
+            id: "legacy-global",
+            agentId: "kuku-native",
+            mode: "ask",
+            createdAt: 1,
+            updatedAt: 1,
+            draft: "",
+            autoApprove: false,
+            messages: [
+              {
+                id: "legacy-message",
+                kind: "text",
+                role: "user",
+                content: "wrong vault",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    localStorage.setItem(
+      scopedChatSessionsStorageKey("/Users/me/Vault A"),
+      JSON.stringify({
+        version: 1,
+        sessions: [
+          {
+            id: "vault-a-session",
+            agentId: "kuku-native",
+            mode: "ask",
+            createdAt: 2,
+            updatedAt: 2,
+            draft: "vault draft",
+            autoApprove: false,
+            messages: [
+              {
+                id: "vault-message",
+                kind: "text",
+                role: "user",
+                content: "right vault",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "plugin:kuku-ai|ai_list_sessions":
+          return [];
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const chat = await loadChatStoreModule();
+
+    await chat.loadSessions();
+
+    expect(mockInvoke).toHaveBeenCalledWith("plugin:kuku-ai|ai_list_sessions", {
+      workingDirectory: "/Users/me/Vault A",
+    });
+    expect(chat.chatState.sessions["vault-a-session"]).toMatchObject({
+      id: "vault-a-session",
+      draft: "vault draft",
+    });
+    expect(chat.chatState.sessions["legacy-global"]).toBeUndefined();
+    expect(chat.chatState.activeSessionId).toBe("vault-a-session");
+  });
+
+  it("ignores backend sessions that do not belong to the active vault", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Vault A");
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "plugin:kuku-ai|ai_list_sessions":
+          return [
+            {
+              localSessionId: "vault-a-session",
+              externalSessionId: null,
+              agentId: "kuku-native",
+              title: "Vault A",
+              updatedAtMs: 30,
+              supportsLoad: false,
+              supportsResume: false,
+              workingDirectory: "/Users/me/Vault A",
+            },
+            {
+              localSessionId: "vault-b-session",
+              externalSessionId: null,
+              agentId: "kuku-native",
+              title: "Vault B",
+              updatedAtMs: 40,
+              supportsLoad: false,
+              supportsResume: false,
+              workingDirectory: "/Users/me/Vault B",
+            },
+            {
+              localSessionId: "legacy-global-session",
+              externalSessionId: null,
+              agentId: "kuku-native",
+              title: "Legacy global",
+              updatedAtMs: 50,
+              supportsLoad: false,
+              supportsResume: false,
+            },
+          ];
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const chat = await loadChatStoreModule();
+
+    await chat.loadSessions();
+
+    expect(chat.getSessionSummaries()).toMatchObject([
+      {
+        id: "vault-a-session",
+        title: "Vault A",
+      },
+    ]);
+    expect(chat.chatState.sessions["vault-b-session"]).toBeUndefined();
+    expect(chat.chatState.sessions["legacy-global-session"]).toBeUndefined();
+  });
+
+  it("hides already-mounted sessions that are outside the active vault", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Vault A");
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "plugin:kuku-ai|ai_new_session":
+          return { sessionId: "vault-a-session" };
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const chat = await loadChatStoreModule();
+    chat.resetToSession("legacy-global-session", "ask");
+
+    await chat.createSession("ask");
+
+    expect(chat.chatState.sessions["legacy-global-session"]).toBeDefined();
+    expect(chat.getSessionSummaries()).toMatchObject([
+      {
+        id: "vault-a-session",
+      },
+    ]);
+  });
+
   it("persists sent messages for the next app launch", async () => {
+    mockGetCurrentVault.mockResolvedValue("/Users/me/Notes");
     mockInvoke.mockImplementation(async (command: string) => {
       switch (command) {
         case "plugin:kuku-ai|ai_new_session":
           return { sessionId: "session-1" };
         case "plugin:kuku-ai|ai_send_message":
+          return undefined;
+        case "plugin:kuku-ai|ai_save_chat_sessions":
           return undefined;
         default:
           throw new Error(`unexpected invoke: ${command}`);
@@ -779,26 +1011,28 @@ describe("ai_chat chat_store session modes", () => {
 
     await expect(chat.sendMessage("remember this")).resolves.toBe(true);
 
-    const raw = localStorage.getItem(CHAT_SESSIONS_STORAGE_KEY);
-    expect(raw).not.toBeNull();
-    expect(JSON.parse(raw ?? "{}")).toMatchObject({
-      version: 1,
-      sessions: [
-        {
-          id: "session-1",
-          agentId: "kuku-native",
-          mode: "ask",
-          draft: "",
-          autoApprove: false,
-          messages: [
-            {
-              kind: "text",
-              role: "user",
-              content: "remember this",
-            },
-          ],
-        },
-      ],
+    expect(localStorage.getItem(CHAT_SESSIONS_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(scopedChatSessionsStorageKey("/Users/me/Notes"))).toBeNull();
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("plugin:kuku-ai|ai_save_chat_sessions", {
+        workingDirectory: "/Users/me/Notes",
+        sessions: [
+          expect.objectContaining({
+            id: "session-1",
+            agentId: "kuku-native",
+            mode: "ask",
+            draft: "",
+            autoApprove: false,
+            messages: [
+              expect.objectContaining({
+                kind: "text",
+                role: "user",
+                content: "remember this",
+              }),
+            ],
+          }),
+        ],
+      });
     });
   });
 

--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_store.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_store.ts
@@ -62,6 +62,7 @@ const BUSY_SESSION_STATUSES: ChatSessionState["status"][] = [
   "applying",
 ];
 const CHAT_SESSIONS_STORAGE_KEY = "kuku.aiChat.sessions.v1";
+const NO_VAULT_SESSION_SCOPE = "no-vault";
 
 interface PersistedChatSessionSnapshot {
   id: string;
@@ -73,6 +74,7 @@ interface PersistedChatSessionSnapshot {
   persistedTitle?: string;
   supportsLoad?: boolean;
   supportsResume?: boolean;
+  workingDirectory?: string | null;
   draft: string;
   autoApprove: boolean;
   messages: ChatMessage[];
@@ -88,8 +90,16 @@ type RuntimeChatMessage =
       toolName: string;
       output: string;
       isError: boolean;
-    };
+};
 
+let currentChatSessionVaultRoot: string | null = null;
+let pendingPersistTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingPersistRequest:
+  | {
+      workingDirectory: string | null;
+      sessions: PersistedChatSessionSnapshot[];
+    }
+  | null = null;
 const [chatState, setChatState] = createStore<ChatStoreState>({
   selectedAgentId: KUKU_NATIVE_AGENT_ID,
   agents: BUILTIN_AGENT_CATALOG,
@@ -162,6 +172,7 @@ function createSessionState(
     mode,
     createdAt: now,
     updatedAt: now,
+    workingDirectory: currentChatSessionVaultRoot,
     draft: "",
     fileAttachments: [],
     messages: [],
@@ -181,6 +192,7 @@ function createPersistedSessionState(session: PersistedAgentSession): ChatSessio
     restored: true,
     supportsLoad: session.supportsLoad,
     supportsResume: session.supportsResume,
+    workingDirectory: normalizeChatSessionVaultRoot(session.workingDirectory),
     createdAt: session.updatedAtMs,
     updatedAt: session.updatedAtMs,
   };
@@ -198,6 +210,9 @@ function createStoredSessionState(
     restored: true,
     supportsLoad: session?.supportsLoad ?? snapshot.supportsLoad,
     supportsResume: session?.supportsResume ?? snapshot.supportsResume,
+    workingDirectory:
+      normalizeChatSessionVaultRoot(session?.workingDirectory ?? snapshot.workingDirectory) ??
+      currentChatSessionVaultRoot,
     createdAt: snapshot.createdAt,
     updatedAt,
     draft: snapshot.draft,
@@ -216,6 +231,30 @@ function getChatSessionStorage(): Storage | null {
     return null;
   }
   return localStorage;
+}
+
+function normalizeChatSessionVaultRoot(root: string | null | undefined): string | null {
+  return typeof root === "string" && root.trim() ? root : null;
+}
+
+function setCurrentChatSessionVaultRoot(root: string | null | undefined): string | null {
+  currentChatSessionVaultRoot = normalizeChatSessionVaultRoot(root);
+  return currentChatSessionVaultRoot;
+}
+
+function chatSessionStorageKey(vaultRoot = currentChatSessionVaultRoot): string {
+  return `${CHAT_SESSIONS_STORAGE_KEY}:${encodeURIComponent(vaultRoot ?? NO_VAULT_SESSION_SCOPE)}`;
+}
+
+function sessionMatchesVaultRoot(
+  session: PersistedAgentSession,
+  vaultRoot: string | null,
+): boolean {
+  return normalizeChatSessionVaultRoot(session.workingDirectory) === vaultRoot;
+}
+
+function chatSessionMatchesCurrentVault(session: ChatSessionState): boolean {
+  return normalizeChatSessionVaultRoot(session.workingDirectory) === currentChatSessionVaultRoot;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -259,8 +298,10 @@ function isStoredChatMessage(value: unknown): value is ChatMessage {
   }
 }
 
-function readLocalSessionSnapshots(): Map<string, PersistedChatSessionSnapshot> {
-  const raw = getChatSessionStorage()?.getItem(CHAT_SESSIONS_STORAGE_KEY);
+function readLocalSessionSnapshots(
+  vaultRoot = currentChatSessionVaultRoot,
+): Map<string, PersistedChatSessionSnapshot> {
+  const raw = getChatSessionStorage()?.getItem(chatSessionStorageKey(vaultRoot));
   if (!raw) return new Map();
 
   try {
@@ -291,6 +332,10 @@ function readLocalSessionSnapshots(): Map<string, PersistedChatSessionSnapshot> 
         supportsLoad: typeof session.supportsLoad === "boolean" ? session.supportsLoad : undefined,
         supportsResume:
           typeof session.supportsResume === "boolean" ? session.supportsResume : undefined,
+        workingDirectory:
+          typeof session.workingDirectory === "string" || session.workingDirectory === null
+            ? normalizeChatSessionVaultRoot(session.workingDirectory)
+            : undefined,
         draft: typeof session.draft === "string" ? session.draft : "",
         autoApprove: session.autoApprove === true,
         messages: Array.isArray(session.messages)
@@ -299,6 +344,58 @@ function readLocalSessionSnapshots(): Map<string, PersistedChatSessionSnapshot> 
       });
     }
 
+    return snapshots;
+  } catch {
+    return new Map();
+  }
+}
+
+function normalizePersistedSessionSnapshot(
+  value: unknown,
+): PersistedChatSessionSnapshot | null {
+  const session = asRecord(value);
+  if (!session || typeof session.id !== "string" || typeof session.agentId !== "string") {
+    return null;
+  }
+
+  return {
+    id: session.id,
+    externalSessionId:
+      typeof session.externalSessionId === "string" || session.externalSessionId === null
+        ? session.externalSessionId
+        : undefined,
+    agentId: session.agentId,
+    mode: isChatMode(session.mode) ? session.mode : "ask",
+    createdAt: typeof session.createdAt === "number" ? session.createdAt : 0,
+    updatedAt: typeof session.updatedAt === "number" ? session.updatedAt : 0,
+    persistedTitle:
+      typeof session.persistedTitle === "string" ? session.persistedTitle : undefined,
+    supportsLoad: typeof session.supportsLoad === "boolean" ? session.supportsLoad : undefined,
+    supportsResume: typeof session.supportsResume === "boolean" ? session.supportsResume : undefined,
+    workingDirectory:
+      typeof session.workingDirectory === "string" || session.workingDirectory === null
+        ? normalizeChatSessionVaultRoot(session.workingDirectory)
+        : undefined,
+    draft: typeof session.draft === "string" ? session.draft : "",
+    autoApprove: session.autoApprove === true,
+    messages: Array.isArray(session.messages) ? session.messages.filter(isStoredChatMessage) : [],
+  };
+}
+
+async function readBackendSessionSnapshots(
+  workingDirectory: string | null,
+): Promise<Map<string, PersistedChatSessionSnapshot>> {
+  try {
+    const values = await invoke<PersistedChatSessionSnapshot[]>(
+      "plugin:kuku-ai|ai_list_chat_sessions",
+      workingDirectory ? { workingDirectory } : undefined,
+    );
+    const snapshots = new Map<string, PersistedChatSessionSnapshot>();
+    for (const value of values) {
+      const snapshot = normalizePersistedSessionSnapshot(value);
+      if (!snapshot) continue;
+      snapshots.set(snapshot.id, snapshot);
+    }
     return snapshots;
   } catch {
     return new Map();
@@ -341,39 +438,86 @@ function serializeSessionForStorage(session: ChatSessionState): PersistedChatSes
     persistedTitle: session.persistedTitle,
     supportsLoad: session.supportsLoad,
     supportsResume: session.supportsResume,
+    workingDirectory: session.workingDirectory ?? currentChatSessionVaultRoot,
     draft: session.draft,
     autoApprove: session.autoApprove,
     messages: session.messages.map(serializeChatMessageForStorage),
   };
 }
 
-function persistChatSessions(): void {
-  const storage = getChatSessionStorage();
-  if (!storage) return;
+async function savePersistedChatSessionSnapshots(
+  workingDirectory: string | null,
+  sessions: PersistedChatSessionSnapshot[],
+): Promise<void> {
+  try {
+    await invoke<void>("plugin:kuku-ai|ai_save_chat_sessions", {
+      ...(workingDirectory ? { workingDirectory } : {}),
+      sessions,
+    });
+  } catch {
+    // Keep the in-memory chat usable even if persistence is temporarily unavailable.
+  }
+}
 
+function persistChatSessions(): void {
   const sessions = Object.values(chatState.sessions)
+    .filter(chatSessionMatchesCurrentVault)
     .map(serializeSessionForStorage)
     .sort((a, b) => b.updatedAt - a.updatedAt);
 
-  try {
-    storage.setItem(
-      CHAT_SESSIONS_STORAGE_KEY,
-      JSON.stringify({
-        version: 1,
-        sessions,
-      }),
-    );
-  } catch {
-    // localStorage can fail in private mode or under quota pressure. The
-    // in-memory chat state should keep working even if restart restore cannot.
+  pendingPersistRequest = {
+    workingDirectory: currentChatSessionVaultRoot,
+    sessions,
+  };
+  if (pendingPersistTimer) {
+    clearTimeout(pendingPersistTimer);
   }
+  pendingPersistTimer = setTimeout(() => {
+    const request = pendingPersistRequest;
+    pendingPersistTimer = null;
+    pendingPersistRequest = null;
+    if (!request) return;
+    void savePersistedChatSessionSnapshots(request.workingDirectory, request.sessions);
+  }, 0);
+}
+
+function clearPendingChatSessionPersist(): void {
+  if (pendingPersistTimer) {
+    clearTimeout(pendingPersistTimer);
+  }
+  pendingPersistTimer = null;
+  pendingPersistRequest = null;
 }
 
 function clearLocalSessionSnapshots(): void {
   try {
-    getChatSessionStorage()?.removeItem(CHAT_SESSIONS_STORAGE_KEY);
+    const storage = getChatSessionStorage();
+    if (!storage) return;
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key === CHAT_SESSIONS_STORAGE_KEY || key?.startsWith(`${CHAT_SESSIONS_STORAGE_KEY}:`)) {
+        keys.push(key);
+      }
+    }
+    for (const key of keys) {
+      storage.removeItem(key);
+    }
   } catch {
     // Ignore storage failures during reset.
+  }
+}
+
+function clearLocalSessionSnapshotsForVault(vaultRoot: string | null): void {
+  try {
+    const storage = getChatSessionStorage();
+    if (!storage) return;
+    storage.removeItem(chatSessionStorageKey(vaultRoot));
+    if (vaultRoot === null) {
+      storage.removeItem(CHAT_SESSIONS_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures during migration cleanup.
   }
 }
 
@@ -471,6 +615,8 @@ function resetChatState(): void {
   });
   lastResponding = false;
   lastSessionTimestamp = 0;
+  currentChatSessionVaultRoot = null;
+  clearPendingChatSessionPersist();
   setContextKey("aiResponding", false);
   clearLocalSessionSnapshots();
 }
@@ -962,6 +1108,7 @@ function sessionTitle(session: ChatSessionState): string {
 
 function getSessionSummaries(): ChatSessionSummary[] {
   return Object.values(chatState.sessions)
+    .filter(chatSessionMatchesCurrentVault)
     .map((session) => ({
       id: session.id,
       agentId: session.agentId,
@@ -997,7 +1144,7 @@ async function createSession(mode: ChatMode = chatState.selectedMode): Promise<s
   const agentId = chatState.selectedAgentId;
   setChatState("isCreatingSession", true);
   try {
-    const workingDirectory = await getCurrentVault();
+    const workingDirectory = setCurrentChatSessionVaultRoot(await getCurrentVault());
     const payload = await invoke<NewSessionPayload>("plugin:kuku-ai|ai_new_session", {
       agentId,
       mode,
@@ -1081,7 +1228,7 @@ async function restoreSession(sessionId: string): Promise<string | null> {
 
   setChatState("isCreatingSession", true);
   try {
-    const workingDirectory = await getCurrentVault();
+    const workingDirectory = setCurrentChatSessionVaultRoot(await getCurrentVault());
     await invoke<NewSessionPayload>("plugin:kuku-ai|ai_restore_session", {
       agentId: session.agentId,
       sessionId,
@@ -1331,14 +1478,36 @@ async function loadAgents(): Promise<void> {
   }
 }
 
-async function loadSessions(): Promise<void> {
-  const localSnapshots = readLocalSessionSnapshots();
-  const sessions = await invoke<PersistedAgentSession[]>("plugin:kuku-ai|ai_list_sessions");
+async function loadSessions(vaultRoot?: string | null): Promise<void> {
+  const workingDirectory = setCurrentChatSessionVaultRoot(
+    vaultRoot === undefined ? await getCurrentVault() : vaultRoot,
+  );
+  setChatState("sessions", {});
+  setChatState("activeSessionId", null);
+  const backendSnapshots = await readBackendSessionSnapshots(workingDirectory);
+  const localSnapshots = readLocalSessionSnapshots(workingDirectory);
+  if (localSnapshots.size > 0) {
+    for (const snapshot of localSnapshots.values()) {
+      const backendSnapshot = backendSnapshots.get(snapshot.id);
+      if (!backendSnapshot || snapshot.updatedAt >= backendSnapshot.updatedAt) {
+        backendSnapshots.set(snapshot.id, snapshot);
+      }
+    }
+    await savePersistedChatSessionSnapshots(workingDirectory, [...backendSnapshots.values()]);
+    clearLocalSessionSnapshotsForVault(workingDirectory);
+  }
+  const sessions = (
+    workingDirectory
+    ? await invoke<PersistedAgentSession[]>("plugin:kuku-ai|ai_list_sessions", {
+        workingDirectory,
+      })
+      : await invoke<PersistedAgentSession[]>("plugin:kuku-ai|ai_list_sessions")
+  ).filter((session) => sessionMatchesVaultRoot(session, workingDirectory));
   const loadedSessionIds = new Set<string>();
   for (const session of sessions) {
     loadedSessionIds.add(session.localSessionId);
     if (chatState.sessions[session.localSessionId]) continue;
-    const snapshot = localSnapshots.get(session.localSessionId);
+    const snapshot = backendSnapshots.get(session.localSessionId);
     setChatState(
       "sessions",
       session.localSessionId,
@@ -1346,7 +1515,7 @@ async function loadSessions(): Promise<void> {
     );
   }
 
-  for (const snapshot of localSnapshots.values()) {
+  for (const snapshot of backendSnapshots.values()) {
     if (loadedSessionIds.has(snapshot.id) || chatState.sessions[snapshot.id]) continue;
     setChatState("sessions", snapshot.id, createStoredSessionState(snapshot));
   }

--- a/apps/desktop/src/plugins/builtin/ai_chat/chat_store.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/chat_store.ts
@@ -93,6 +93,7 @@ type RuntimeChatMessage =
 };
 
 let currentChatSessionVaultRoot: string | null = null;
+const pendingLegacyHandoffBySessionId = new Map<string, string>();
 let pendingPersistTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingPersistRequest:
   | {
@@ -616,6 +617,7 @@ function resetChatState(): void {
   lastResponding = false;
   lastSessionTimestamp = 0;
   currentChatSessionVaultRoot = null;
+  pendingLegacyHandoffBySessionId.clear();
   clearPendingChatSessionPersist();
   setContextKey("aiResponding", false);
   clearLocalSessionSnapshots();
@@ -1215,11 +1217,68 @@ async function ensureSession(): Promise<string | null> {
       setChatState("sessions", active.id, "mode", mode);
     }
     if (active.restored) {
+      if (!canRestoreSession(active)) {
+        return createContinuationSession(active, mode);
+      }
       return restoreSession(active.id);
     }
     return active.id;
   }
   return createSession(mode);
+}
+
+async function createContinuationSession(
+  previousSession: ChatSessionState,
+  mode: ChatMode,
+): Promise<string | null> {
+  const handoffPrompt = buildLegacyAcpHandoffPrompt(previousSession);
+  const previousMessages = previousSession.messages.map((message) => ({ ...message }));
+  const sessionId = await createSession(mode);
+  if (!sessionId) return null;
+
+  batch(() => {
+    setChatState("sessions", sessionId, "messages", previousMessages);
+    setChatState("sessions", sessionId, "draft", previousSession.draft);
+    setChatState("sessions", sessionId, "autoApprove", previousSession.autoApprove);
+  });
+  if (handoffPrompt) {
+    pendingLegacyHandoffBySessionId.set(sessionId, handoffPrompt);
+  }
+  persistChatSessions();
+  return sessionId;
+}
+
+function canRestoreSession(session: ChatSessionState): boolean {
+  if (session.agentId === KUKU_NATIVE_AGENT_ID) {
+    return true;
+  }
+  return typeof session.externalSessionId === "string" && session.externalSessionId.trim() !== "";
+}
+
+function buildLegacyAcpHandoffPrompt(session: ChatSessionState): string | null {
+  const transcript = session.messages
+    .flatMap((message) => {
+      if (message.kind !== "text") return [];
+      const content = message.content.trim();
+      if (!content) return [];
+      return `${message.role.toUpperCase()}: ${content}`;
+    })
+    .join("\n\n")
+    .trim();
+  if (!transcript) return null;
+
+  const maxLength = 12_000;
+  const clippedTranscript =
+    transcript.length > maxLength ? transcript.slice(transcript.length - maxLength) : transcript;
+
+  return [
+    "You are continuing a Kuku chat whose external ACP session could not be reattached.",
+    "Use the prior local transcript below as conversation context. Do not mention this handoff unless the user asks.",
+    "",
+    "<previous_transcript>",
+    clippedTranscript,
+    "</previous_transcript>",
+  ].join("\n");
 }
 
 async function restoreSession(sessionId: string): Promise<string | null> {
@@ -1310,17 +1369,21 @@ async function sendMessage(content: string, options: SendMessageOptions = {}): P
     setChatState("sessions", sessionId, "error", null);
     setChatState("sessions", sessionId, "finishReason", null);
 
+    const handoffPrompt = pendingLegacyHandoffBySessionId.get(sessionId);
+    const outboundContent = handoffPrompt ? `${handoffPrompt}\n\n${trimmed}` : trimmed;
+
     await invoke<void>("plugin:kuku-ai|ai_send_message", {
       agentId: session.agentId,
       sessionId,
       mode: chatState.selectedMode,
-      content: trimmed,
+      content: outboundContent,
       editorContext: {
         ...editorContext,
         selectedText: preparedSelection.selectedText,
         embeddedFiles: preparedFiles.embeddedFiles,
       },
     });
+    pendingLegacyHandoffBySessionId.delete(sessionId);
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/approval_widget.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/approval_widget.tsx
@@ -5,7 +5,7 @@ import ScrollArea from "~/components/scroll_area";
 import { canOpenApprovalDiff, closeApprovalDiff, openApprovalDiff } from "../approval_diff";
 import { resolveApproval } from "../chat_store";
 import type { ChatApprovalMessage } from "../types";
-import { formatToolIdentity, getToolInfo } from "../tool_identity";
+import { formatToolIdentity, getToolDisplayInfo } from "../tool_identity";
 import {
   getApprovalStatusLabel,
   getApprovalStatusTone,
@@ -35,7 +35,7 @@ function ApprovalWidget(props: {
   // `isPending()` becomes false, so no need to reset this signal.
   const [resolving, setResolving] = createSignal(false);
   const toolIdentity = () => formatToolIdentity(props.item.toolId, props.item.toolName);
-  const toolInfo = () => getToolInfo(props.item.toolId ?? props.item.toolName);
+  const toolInfo = () => getToolDisplayInfo(props.item.toolId, props.item.toolName);
   const showIdentity = () => toolIdentity() !== toolInfo().label;
 
   return (

--- a/apps/desktop/src/plugins/builtin/ai_chat/components/tool_progress.tsx
+++ b/apps/desktop/src/plugins/builtin/ai_chat/components/tool_progress.tsx
@@ -1,11 +1,11 @@
 import { For, Show, Switch, Match, type JSX } from "solid-js";
 
 import type { ChatApprovalMessage, ChatToolMessage } from "../types";
-import { getToolInfo, getToolKind } from "../tool_identity";
+import { getToolDisplayInfo, getToolDisplayKind } from "../tool_identity";
 
 function getToolDetail(item: ChatToolMessage): string | null {
   const args = item.arguments;
-  switch (getToolKind(item.toolId ?? item.toolName)) {
+  switch (getToolDisplayKind(item.toolId, item.toolName)) {
     case "search_vault":
     case "search_notes": {
       const query = typeof args.query === "string" ? args.query : null;
@@ -43,7 +43,7 @@ function ToolProgress(props: ToolProgressProps): JSX.Element {
     <div class="my-0.5 w-full space-y-1 border-b border-border/35 bg-bg-secondary/20 px-0 py-2 text-xs">
       <For each={props.tools}>
         {(item) => {
-          const info = getToolInfo(item.toolId ?? item.toolName);
+          const info = getToolDisplayInfo(item.toolId, item.toolName);
           const isActive = !item.success && !item.error;
           const detail = getToolDetail(item);
           const isLinked = () =>

--- a/apps/desktop/src/plugins/builtin/ai_chat/index.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/index.ts
@@ -84,6 +84,12 @@ const aiChatPlugin: KukuPlugin = {
 
     const disposeEvents = await createAiEventBridge();
     ctx.track(disposeEvents);
+    ctx.events.on("vault:opened", ({ rootPath }) => {
+      void loadSessions(rootPath);
+    });
+    ctx.events.on("vault:closed", () => {
+      void loadSessions(null);
+    });
 
     try {
       await loadConfig();

--- a/apps/desktop/src/plugins/builtin/ai_chat/tool_identity.test.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/tool_identity.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { formatToolIdentity, getToolDisplayInfo, getToolDisplayKind } from "./tool_identity";
+
+describe("ai_chat tool identity", () => {
+  it("uses the ACP tool title instead of the synthetic call id for display", () => {
+    const info = getToolDisplayInfo("acp.call_6CbUgZx6ORTi4qsMuAlKHbiB", "Read file");
+
+    expect(info.label).toBe("Read file");
+    expect(formatToolIdentity("acp.call_6CbUgZx6ORTi4qsMuAlKHbiB", "Read file")).toBe(
+      "Read file",
+    );
+  });
+
+  it("keeps built-in tool ids available for kind-specific details", () => {
+    expect(getToolDisplayKind("builtin.read_file", "read_file")).toBe("read_file");
+  });
+});

--- a/apps/desktop/src/plugins/builtin/ai_chat/tool_identity.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/tool_identity.ts
@@ -166,9 +166,47 @@ function getToolInfo(toolIdOrName: string): {
   };
 }
 
+function isSyntheticAcpToolId(toolId: string | undefined | null): boolean {
+  return typeof toolId === "string" && toolId.startsWith("acp.");
+}
+
+function getToolDisplayIdentity(toolId?: string | null, toolName?: string | null): string {
+  const trimmedName = typeof toolName === "string" ? toolName.trim() : "";
+  if (isSyntheticAcpToolId(toolId) && trimmedName) {
+    return trimmedName;
+  }
+  return toolId ?? toolName ?? "";
+}
+
+function getToolDisplayInfo(
+  toolId?: string | null,
+  toolName?: string | null,
+): {
+  label: string;
+  activeLabel: string;
+  description: string;
+} {
+  return getToolInfo(getToolDisplayIdentity(toolId, toolName));
+}
+
+function getToolDisplayKind(toolId?: string | null, toolName?: string | null): string {
+  return getToolKind(getToolDisplayIdentity(toolId, toolName));
+}
+
 function formatToolIdentity(toolId?: string, toolName?: string): string {
-  const resolved = toolId ?? canonicalToolId(toolName ?? "");
+  const displayIdentity = getToolDisplayIdentity(toolId, toolName);
+  const resolved = isSyntheticAcpToolId(toolId)
+    ? displayIdentity
+    : (toolId ?? canonicalToolId(toolName ?? ""));
   return resolved || toolName || "";
 }
 
-export { canonicalToolId, formatToolIdentity, getToolInfo, getToolKind };
+export {
+  canonicalToolId,
+  formatToolIdentity,
+  getToolDisplayInfo,
+  getToolDisplayKind,
+  getToolDisplayIdentity,
+  getToolInfo,
+  getToolKind,
+};

--- a/apps/desktop/src/plugins/builtin/ai_chat/types.ts
+++ b/apps/desktop/src/plugins/builtin/ai_chat/types.ts
@@ -186,6 +186,7 @@ interface ChatSessionState {
   restored?: boolean;
   supportsLoad?: boolean;
   supportsResume?: boolean;
+  workingDirectory?: string | null;
   draft: string;
   fileAttachments: ChatFileAttachmentDraft[];
   messages: ChatMessage[];
@@ -247,6 +248,7 @@ interface PersistedAgentSession {
   updatedAtMs: number;
   supportsLoad: boolean;
   supportsResume: boolean;
+  workingDirectory?: string | null;
 }
 
 interface ChatSnapshotSource {

--- a/crates/kuku-ai/build.rs
+++ b/crates/kuku-ai/build.rs
@@ -10,6 +10,8 @@ const COMMANDS: &[&str] = &[
     "ai_list_tools",
     "ai_list_agents",
     "ai_list_sessions",
+    "ai_list_chat_sessions",
+    "ai_save_chat_sessions",
     "ai_resolve_approval",
     "ai_register_proxy_tool",
     "ai_unregister_proxy_tool",

--- a/crates/kuku-ai/permissions/autogenerated/commands/ai_list_chat_sessions.toml
+++ b/crates/kuku-ai/permissions/autogenerated/commands/ai_list_chat_sessions.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-ai-list-chat-sessions"
+description = "Enables the ai_list_chat_sessions command without any pre-configured scope."
+commands.allow = ["ai_list_chat_sessions"]
+
+[[permission]]
+identifier = "deny-ai-list-chat-sessions"
+description = "Denies the ai_list_chat_sessions command without any pre-configured scope."
+commands.deny = ["ai_list_chat_sessions"]

--- a/crates/kuku-ai/permissions/autogenerated/commands/ai_save_chat_sessions.toml
+++ b/crates/kuku-ai/permissions/autogenerated/commands/ai_save_chat_sessions.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-ai-save-chat-sessions"
+description = "Enables the ai_save_chat_sessions command without any pre-configured scope."
+commands.allow = ["ai_save_chat_sessions"]
+
+[[permission]]
+identifier = "deny-ai-save-chat-sessions"
+description = "Denies the ai_save_chat_sessions command without any pre-configured scope."
+commands.deny = ["ai_save_chat_sessions"]

--- a/crates/kuku-ai/permissions/autogenerated/reference.md
+++ b/crates/kuku-ai/permissions/autogenerated/reference.md
@@ -15,6 +15,8 @@ Allows the AI plugin commands.
 - `allow-ai-list-tools`
 - `allow-ai-list-agents`
 - `allow-ai-list-sessions`
+- `allow-ai-list-chat-sessions`
+- `allow-ai-save-chat-sessions`
 - `allow-ai-resolve-approval`
 - `allow-ai-register-proxy-tool`
 - `allow-ai-unregister-proxy-tool`
@@ -129,6 +131,32 @@ Enables the ai_list_agents command without any pre-configured scope.
 <td>
 
 Denies the ai_list_agents command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`kuku-ai:allow-ai-list-chat-sessions`
+
+</td>
+<td>
+
+Enables the ai_list_chat_sessions command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`kuku-ai:deny-ai-list-chat-sessions`
+
+</td>
+<td>
+
+Denies the ai_list_chat_sessions command without any pre-configured scope.
 
 </td>
 </tr>
@@ -311,6 +339,32 @@ Enables the ai_restore_session command without any pre-configured scope.
 <td>
 
 Denies the ai_restore_session command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`kuku-ai:allow-ai-save-chat-sessions`
+
+</td>
+<td>
+
+Enables the ai_save_chat_sessions command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`kuku-ai:deny-ai-save-chat-sessions`
+
+</td>
+<td>
+
+Denies the ai_save_chat_sessions command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/kuku-ai/permissions/default.toml
+++ b/crates/kuku-ai/permissions/default.toml
@@ -14,6 +14,8 @@ permissions = [
   "allow-ai-list-tools",
   "allow-ai-list-agents",
   "allow-ai-list-sessions",
+  "allow-ai-list-chat-sessions",
+  "allow-ai-save-chat-sessions",
   "allow-ai-resolve-approval",
   "allow-ai-register-proxy-tool",
   "allow-ai-unregister-proxy-tool",

--- a/crates/kuku-ai/permissions/schemas/schema.json
+++ b/crates/kuku-ai/permissions/schemas/schema.json
@@ -343,6 +343,18 @@
           "markdownDescription": "Denies the ai_list_agents command without any pre-configured scope."
         },
         {
+          "description": "Enables the ai_list_chat_sessions command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-ai-list-chat-sessions",
+          "markdownDescription": "Enables the ai_list_chat_sessions command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the ai_list_chat_sessions command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-ai-list-chat-sessions",
+          "markdownDescription": "Denies the ai_list_chat_sessions command without any pre-configured scope."
+        },
+        {
           "description": "Enables the ai_list_sessions command without any pre-configured scope.",
           "type": "string",
           "const": "allow-ai-list-sessions",
@@ -427,6 +439,18 @@
           "markdownDescription": "Denies the ai_restore_session command without any pre-configured scope."
         },
         {
+          "description": "Enables the ai_save_chat_sessions command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-ai-save-chat-sessions",
+          "markdownDescription": "Enables the ai_save_chat_sessions command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the ai_save_chat_sessions command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-ai-save-chat-sessions",
+          "markdownDescription": "Denies the ai_save_chat_sessions command without any pre-configured scope."
+        },
+        {
           "description": "Enables the ai_send_message command without any pre-configured scope.",
           "type": "string",
           "const": "allow-ai-send-message",
@@ -475,10 +499,10 @@
           "markdownDescription": "Denies the ai_unregister_proxy_tool command without any pre-configured scope."
         },
         {
-          "description": "Allows the AI plugin commands.\n#### This default permission set includes:\n\n- `allow-ai-new-session`\n- `allow-ai-restore-session`\n- `allow-ai-send-message`\n- `allow-ai-cancel`\n- `allow-ai-close-session`\n- `allow-ai-get-config`\n- `allow-ai-set-config`\n- `allow-ai-reset-state`\n- `allow-ai-list-tools`\n- `allow-ai-list-agents`\n- `allow-ai-list-sessions`\n- `allow-ai-resolve-approval`\n- `allow-ai-register-proxy-tool`\n- `allow-ai-unregister-proxy-tool`\n- `allow-ai-submit-proxy-tool-result`",
+          "description": "Allows the AI plugin commands.\n#### This default permission set includes:\n\n- `allow-ai-new-session`\n- `allow-ai-restore-session`\n- `allow-ai-send-message`\n- `allow-ai-cancel`\n- `allow-ai-close-session`\n- `allow-ai-get-config`\n- `allow-ai-set-config`\n- `allow-ai-reset-state`\n- `allow-ai-list-tools`\n- `allow-ai-list-agents`\n- `allow-ai-list-sessions`\n- `allow-ai-list-chat-sessions`\n- `allow-ai-save-chat-sessions`\n- `allow-ai-resolve-approval`\n- `allow-ai-register-proxy-tool`\n- `allow-ai-unregister-proxy-tool`\n- `allow-ai-submit-proxy-tool-result`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Allows the AI plugin commands.\n#### This default permission set includes:\n\n- `allow-ai-new-session`\n- `allow-ai-restore-session`\n- `allow-ai-send-message`\n- `allow-ai-cancel`\n- `allow-ai-close-session`\n- `allow-ai-get-config`\n- `allow-ai-set-config`\n- `allow-ai-reset-state`\n- `allow-ai-list-tools`\n- `allow-ai-list-agents`\n- `allow-ai-list-sessions`\n- `allow-ai-resolve-approval`\n- `allow-ai-register-proxy-tool`\n- `allow-ai-unregister-proxy-tool`\n- `allow-ai-submit-proxy-tool-result`"
+          "markdownDescription": "Allows the AI plugin commands.\n#### This default permission set includes:\n\n- `allow-ai-new-session`\n- `allow-ai-restore-session`\n- `allow-ai-send-message`\n- `allow-ai-cancel`\n- `allow-ai-close-session`\n- `allow-ai-get-config`\n- `allow-ai-set-config`\n- `allow-ai-reset-state`\n- `allow-ai-list-tools`\n- `allow-ai-list-agents`\n- `allow-ai-list-sessions`\n- `allow-ai-list-chat-sessions`\n- `allow-ai-save-chat-sessions`\n- `allow-ai-resolve-approval`\n- `allow-ai-register-proxy-tool`\n- `allow-ai-unregister-proxy-tool`\n- `allow-ai-submit-proxy-tool-result`"
         }
       ]
     }

--- a/crates/kuku-ai/src/agent_runtime/store.rs
+++ b/crates/kuku-ai/src/agent_runtime/store.rs
@@ -7,7 +7,7 @@ use std::{
 
 use parking_lot::RwLock;
 
-use crate::{AgentId, AiError, PersistedAgentSession};
+use crate::{AgentId, AiError, PersistedAgentSession, PersistedChatSessionSnapshot};
 
 #[derive(Clone)]
 pub(crate) struct AgentSessionStore {
@@ -35,14 +35,30 @@ impl AgentSessionStore {
         }
     }
 
-    pub(crate) fn from_data_dir(data_dir: PathBuf) -> Self {
-        Self::new(data_dir.join("ai").join("sessions.json"))
+    pub(crate) fn from_data_root(data_root: PathBuf) -> Self {
+        Self::new(data_root.join("ai").join("sessions.json"))
     }
 
     pub(crate) fn list(&self) -> Vec<PersistedAgentSession> {
-        let mut sessions = self.sessions.read().clone();
-        sessions.sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
-        sessions
+        sort_sessions(self.sessions.read().clone())
+    }
+
+    pub(crate) fn list_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+    ) -> Vec<PersistedAgentSession> {
+        let working_directory = normalize_working_directory(working_directory);
+        sort_sessions(
+            self.sessions
+                .read()
+                .iter()
+                .filter(|session| {
+                    normalize_working_directory(session.working_directory.as_deref())
+                        == working_directory
+                })
+                .cloned()
+                .collect(),
+        )
     }
 
     pub(crate) fn upsert(&self, session: PersistedAgentSession) -> Result<(), AiError> {
@@ -67,6 +83,7 @@ impl AgentSessionStore {
         agent_id: AgentId,
         supports_load: bool,
         supports_resume: bool,
+        working_directory: Option<String>,
     ) -> Result<(), AiError> {
         self.upsert(PersistedAgentSession {
             local_session_id,
@@ -76,6 +93,8 @@ impl AgentSessionStore {
             updated_at_ms: now_ms(),
             supports_load,
             supports_resume,
+            working_directory: normalize_working_directory(working_directory.as_deref())
+                .map(str::to_string),
         })
     }
 
@@ -142,6 +161,109 @@ impl AgentSessionStore {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct ChatSessionSnapshotStore {
+    path: PathBuf,
+    sessions: Arc<RwLock<Vec<PersistedChatSessionSnapshot>>>,
+    load_error: Arc<RwLock<Option<String>>>,
+}
+
+impl Default for ChatSessionSnapshotStore {
+    fn default() -> Self {
+        Self::new(default_chat_snapshot_store_path())
+    }
+}
+
+impl ChatSessionSnapshotStore {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        let (sessions, load_error) = match read_chat_session_snapshots(&path) {
+            Ok(sessions) => (sessions, None),
+            Err(error) => (Vec::new(), Some(error.to_string())),
+        };
+        Self {
+            path,
+            sessions: Arc::new(RwLock::new(sessions)),
+            load_error: Arc::new(RwLock::new(load_error)),
+        }
+    }
+
+    pub(crate) fn from_data_root(data_root: PathBuf) -> Self {
+        Self::new(data_root.join("ai").join("chat_sessions.json"))
+    }
+
+    pub(crate) fn list_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+    ) -> Vec<PersistedChatSessionSnapshot> {
+        let working_directory = normalize_working_directory(working_directory);
+        sort_chat_session_snapshots(
+            self.sessions
+                .read()
+                .iter()
+                .filter(|session| {
+                    normalize_working_directory(session.working_directory.as_deref())
+                        == working_directory
+                })
+                .cloned()
+                .collect(),
+        )
+    }
+
+    pub(crate) fn replace_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+        mut snapshots: Vec<PersistedChatSessionSnapshot>,
+    ) -> Result<(), AiError> {
+        let working_directory = normalize_working_directory(working_directory).map(str::to_string);
+        {
+            let mut sessions = self.sessions.write();
+            sessions.retain(|session| {
+                normalize_working_directory(session.working_directory.as_deref())
+                    != working_directory.as_deref()
+            });
+            for snapshot in &mut snapshots {
+                snapshot.working_directory = working_directory.clone();
+            }
+            sessions.extend(snapshots);
+        }
+        self.flush()
+    }
+
+    pub(crate) fn clear(&self) -> Result<(), AiError> {
+        {
+            self.sessions.write().clear();
+            *self.load_error.write() = None;
+        }
+        match fs::remove_file(&self.path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(AiError::State(format!(
+                "Failed to delete AI chat session store: {error}"
+            ))),
+        }
+    }
+
+    fn flush(&self) -> Result<(), AiError> {
+        if let Some(error) = self.load_error.read().as_ref() {
+            return Err(AiError::State(format!(
+                "Refusing to overwrite unreadable AI chat session store: {error}"
+            )));
+        }
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                AiError::State(format!(
+                    "Failed to create AI chat session store directory: {error}"
+                ))
+            })?;
+        }
+        let json = serde_json::to_string_pretty(&*self.sessions.read()).map_err(|error| {
+            AiError::State(format!("Failed to serialize AI chat sessions: {error}"))
+        })?;
+        fs::write(&self.path, json)
+            .map_err(|error| AiError::State(format!("Failed to write AI chat sessions: {error}")))
+    }
+}
+
 fn read_sessions(path: &Path) -> Result<Vec<PersistedAgentSession>, AiError> {
     if !path.exists() {
         return Ok(Vec::new());
@@ -152,9 +274,47 @@ fn read_sessions(path: &Path) -> Result<Vec<PersistedAgentSession>, AiError> {
         .map_err(|error| AiError::State(format!("Failed to parse AI sessions: {error}")))
 }
 
+fn read_chat_session_snapshots(path: &Path) -> Result<Vec<PersistedChatSessionSnapshot>, AiError> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(path)
+        .map_err(|error| AiError::State(format!("Failed to read AI chat sessions: {error}")))?;
+    serde_json::from_str(&content)
+        .map_err(|error| AiError::State(format!("Failed to parse AI chat sessions: {error}")))
+}
+
+fn sort_sessions(mut sessions: Vec<PersistedAgentSession>) -> Vec<PersistedAgentSession> {
+    sessions.sort_by(|left, right| right.updated_at_ms.cmp(&left.updated_at_ms));
+    sessions
+}
+
+fn sort_chat_session_snapshots(
+    mut sessions: Vec<PersistedChatSessionSnapshot>,
+) -> Vec<PersistedChatSessionSnapshot> {
+    sessions.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+    sessions
+}
+
+fn normalize_working_directory(value: Option<&str>) -> Option<&str> {
+    value.and_then(|directory| {
+        let trimmed = directory.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    })
+}
+
 fn default_store_path() -> PathBuf {
     let root = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
     root.join(".kuku").join("ai").join("sessions.json")
+}
+
+fn default_chat_snapshot_store_path() -> PathBuf {
+    let root = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
+    root.join(".kuku").join("ai").join("chat_sessions.json")
 }
 
 fn now_ms() -> u64 {
@@ -184,6 +344,7 @@ mod tests {
                 AgentId("codex-acp".to_string()),
                 true,
                 false,
+                None,
             )
             .unwrap();
 
@@ -212,6 +373,7 @@ mod tests {
                 AgentId::kuku_native(),
                 false,
                 false,
+                None,
             )
             .unwrap();
         store
@@ -221,6 +383,7 @@ mod tests {
                 AgentId("codex-acp".to_string()),
                 true,
                 false,
+                None,
             )
             .unwrap();
         store
@@ -230,6 +393,51 @@ mod tests {
         let sessions = store.list();
         assert_eq!(sessions[0].local_session_id, "local-1");
         assert_eq!(sessions[0].title, "Summarize workspace");
+    }
+
+    #[test]
+    fn persisted_agent_sessions_can_be_listed_by_working_directory() {
+        let path = test_store_path("working-directory");
+        let store = AgentSessionStore::new(path);
+
+        store
+            .record_new_session(
+                "vault-a".to_string(),
+                None,
+                AgentId::kuku_native(),
+                false,
+                false,
+                Some("/Users/me/Vault A".to_string()),
+            )
+            .unwrap();
+        store
+            .record_new_session(
+                "vault-b".to_string(),
+                None,
+                AgentId::kuku_native(),
+                false,
+                false,
+                Some("/Users/me/Vault B".to_string()),
+            )
+            .unwrap();
+        store
+            .record_new_session(
+                "no-vault".to_string(),
+                None,
+                AgentId::kuku_native(),
+                false,
+                false,
+                None,
+            )
+            .unwrap();
+
+        let vault_a_sessions = store.list_for_working_directory(Some("/Users/me/Vault A"));
+        assert_eq!(vault_a_sessions.len(), 1);
+        assert_eq!(vault_a_sessions[0].local_session_id, "vault-a");
+
+        let no_vault_sessions = store.list_for_working_directory(None);
+        assert_eq!(no_vault_sessions.len(), 1);
+        assert_eq!(no_vault_sessions[0].local_session_id, "no-vault");
     }
 
     #[test]
@@ -244,6 +452,7 @@ mod tests {
                 AgentId::kuku_native(),
                 false,
                 false,
+                None,
             )
             .unwrap();
         store
@@ -253,6 +462,7 @@ mod tests {
                 AgentId("codex-acp".to_string()),
                 true,
                 true,
+                None,
             )
             .unwrap();
 
@@ -277,10 +487,96 @@ mod tests {
                 AgentId::kuku_native(),
                 false,
                 false,
+                None,
             )
             .unwrap_err();
 
         assert!(error.to_string().contains("Refusing to overwrite"));
         assert_eq!(fs::read_to_string(path).unwrap(), "{not json");
+    }
+
+    #[test]
+    fn chat_session_snapshots_replace_only_the_requested_working_directory() {
+        let path = test_store_path("chat-snapshots");
+        let store = ChatSessionSnapshotStore::new(path.clone());
+
+        store
+            .replace_for_working_directory(
+                Some("/Users/me/Vault A"),
+                vec![PersistedChatSessionSnapshot {
+                    id: "vault-a-1".to_string(),
+                    external_session_id: None,
+                    agent_id: AgentId::kuku_native(),
+                    mode: crate::ChatMode::Ask,
+                    created_at: 1,
+                    updated_at: 1,
+                    persisted_title: None,
+                    supports_load: None,
+                    supports_resume: None,
+                    working_directory: None,
+                    draft: String::new(),
+                    auto_approve: false,
+                    messages: vec![serde_json::json!({
+                        "id": "message-1",
+                        "kind": "text",
+                        "role": "user",
+                        "content": "vault a"
+                    })],
+                }],
+            )
+            .unwrap();
+        store
+            .replace_for_working_directory(
+                Some("/Users/me/Vault B"),
+                vec![PersistedChatSessionSnapshot {
+                    id: "vault-b-1".to_string(),
+                    external_session_id: None,
+                    agent_id: AgentId::kuku_native(),
+                    mode: crate::ChatMode::Ask,
+                    created_at: 2,
+                    updated_at: 2,
+                    persisted_title: None,
+                    supports_load: None,
+                    supports_resume: None,
+                    working_directory: None,
+                    draft: String::new(),
+                    auto_approve: false,
+                    messages: Vec::new(),
+                }],
+            )
+            .unwrap();
+        store
+            .replace_for_working_directory(
+                Some("/Users/me/Vault A"),
+                vec![PersistedChatSessionSnapshot {
+                    id: "vault-a-2".to_string(),
+                    external_session_id: None,
+                    agent_id: AgentId::kuku_native(),
+                    mode: crate::ChatMode::Agent,
+                    created_at: 3,
+                    updated_at: 3,
+                    persisted_title: Some("new a".to_string()),
+                    supports_load: Some(true),
+                    supports_resume: Some(false),
+                    working_directory: Some("/wrong/root".to_string()),
+                    draft: "draft".to_string(),
+                    auto_approve: true,
+                    messages: Vec::new(),
+                }],
+            )
+            .unwrap();
+
+        let loaded = ChatSessionSnapshotStore::new(path);
+        let vault_a = loaded.list_for_working_directory(Some("/Users/me/Vault A"));
+        let vault_b = loaded.list_for_working_directory(Some("/Users/me/Vault B"));
+
+        assert_eq!(vault_a.len(), 1);
+        assert_eq!(vault_a[0].id, "vault-a-2");
+        assert_eq!(
+            vault_a[0].working_directory.as_deref(),
+            Some("/Users/me/Vault A")
+        );
+        assert_eq!(vault_b.len(), 1);
+        assert_eq!(vault_b[0].id, "vault-b-1");
     }
 }

--- a/crates/kuku-ai/src/commands.rs
+++ b/crates/kuku-ai/src/commands.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::{
     AgentId, AiConfig, AiError, AiState, ChatMode, EditorContext, NewSessionPayload,
-    PersistedAgentSession, ProxyToolDescriptor, ProxyToolResult,
+    PersistedAgentSession, PersistedChatSessionSnapshot, ProxyToolDescriptor, ProxyToolResult,
     agent_runtime::{AgentNewSessionRequest, AgentRestoreSessionRequest, AgentSendMessageRequest},
     types::ChatMessage,
 };
@@ -18,6 +18,9 @@ pub async fn ai_new_session(
     working_directory: Option<String>,
 ) -> Result<NewSessionPayload, String> {
     let agent_id = agent_id.unwrap_or_else(AgentId::kuku_native);
+    let working_directory_path = working_directory
+        .as_ref()
+        .map(|directory| PathBuf::from(directory));
     let runtime = state
         .runtime_for_agent(&agent_id)
         .map_err(|error| error.to_string())?;
@@ -27,12 +30,14 @@ pub async fn ai_new_session(
             &state,
             AgentNewSessionRequest {
                 mode,
-                working_directory: working_directory.map(PathBuf::from),
+                working_directory: working_directory_path,
             },
         )
         .await
         .map_err(|error| error.to_string())?;
-    if let Err(error) = state.record_agent_session(payload.session_id.clone(), agent_id) {
+    if let Err(error) =
+        state.record_agent_session(payload.session_id.clone(), agent_id, working_directory)
+    {
         log::warn!("failed to persist AI session metadata: {error}");
     }
     Ok(payload)
@@ -166,8 +171,31 @@ pub async fn ai_list_agents(
 #[command]
 pub async fn ai_list_sessions(
     state: State<'_, AiState>,
+    working_directory: Option<String>,
 ) -> Result<Vec<PersistedAgentSession>, String> {
-    Ok(state.persisted_sessions())
+    Ok(state.persisted_sessions_for_working_directory(working_directory.as_deref()))
+}
+
+#[command]
+pub async fn ai_list_chat_sessions(
+    state: State<'_, AiState>,
+    working_directory: Option<String>,
+) -> Result<Vec<PersistedChatSessionSnapshot>, String> {
+    Ok(state.persisted_chat_sessions_for_working_directory(working_directory.as_deref()))
+}
+
+#[command]
+pub async fn ai_save_chat_sessions(
+    state: State<'_, AiState>,
+    working_directory: Option<String>,
+    sessions: Vec<PersistedChatSessionSnapshot>,
+) -> Result<(), String> {
+    state
+        .replace_persisted_chat_sessions_for_working_directory(
+            working_directory.as_deref(),
+            sessions,
+        )
+        .map_err(|error| error.to_string())
 }
 
 #[command]

--- a/crates/kuku-ai/src/lib.rs
+++ b/crates/kuku-ai/src/lib.rs
@@ -12,7 +12,10 @@ mod state;
 mod tools;
 mod types;
 
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 pub use error::{AiError, ToolError};
 pub use host::AiHostBindings;
@@ -29,19 +32,13 @@ pub use tools::{
 pub use types::{
     AgentDescriptor, AgentId, AgentKind, AiConfig, ChatMode, EditorContext, EmbeddedFileContext,
     ExternalAgentConfig, FinishReason, ModelToolCall, NewAgentSessionRequest, NewSessionPayload,
-    PersistedAgentSession, ProviderKind,
+    PersistedAgentSession, PersistedChatSessionSnapshot, ProviderKind,
 };
 
 pub fn init() -> TauriPlugin<Wry> {
     Builder::new("kuku-ai")
         .setup(|app, _api| {
-            let state = match app.path().app_data_dir() {
-                Ok(data_dir) => AiState::with_data_dir(data_dir),
-                Err(error) => {
-                    log::warn!("failed to resolve AI session data directory: {error}");
-                    AiState::default()
-                }
-            };
+            let state = AiState::with_data_root(resolve_data_root(&app.config().identifier));
             app.manage(state);
             Ok(())
         })
@@ -57,6 +54,8 @@ pub fn init() -> TauriPlugin<Wry> {
             commands::ai_list_tools,
             commands::ai_list_agents,
             commands::ai_list_sessions,
+            commands::ai_list_chat_sessions,
+            commands::ai_save_chat_sessions,
             commands::ai_resolve_approval,
             commands::ai_register_proxy_tool,
             commands::ai_unregister_proxy_tool,
@@ -73,4 +72,41 @@ pub fn register_host(app: &AppHandle<Wry>, host: Arc<dyn AiHostBindings>) {
 pub fn register_tool(app: &AppHandle<Wry>, tool: Arc<dyn AiNativeTool>) {
     let state = app.state::<AiState>();
     state.register_tool(tool);
+}
+
+fn resolve_data_root(identifier: &str) -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(std::env::temp_dir);
+    data_root_for_identifier(identifier, &home)
+}
+
+fn data_root_for_identifier(identifier: &str, home: &Path) -> PathBuf {
+    let suffix = match identifier {
+        "mom.kuku.app.dev" => ".dev",
+        "mom.kuku.app.preview" => ".preview",
+        _ => "",
+    };
+    if suffix.is_empty() {
+        home.join(".kuku")
+    } else {
+        home.join(format!(".kuku{suffix}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    #[test]
+    fn data_root_for_identifier_uses_kuku_dev_for_development_bundle() {
+        let home = Path::new("/Users/proposition");
+
+        assert_eq!(
+            super::data_root_for_identifier("mom.kuku.app.dev", home),
+            home.join(".kuku.dev")
+        );
+        assert_eq!(
+            super::data_root_for_identifier("mom.kuku.app", home),
+            home.join(".kuku")
+        );
+    }
 }

--- a/crates/kuku-ai/src/state.rs
+++ b/crates/kuku-ai/src/state.rs
@@ -9,14 +9,14 @@ use crate::{
         AgentRuntime,
         acp::{AcpAgentRuntime, AcpSessionHandle},
         native::NativeAgentRuntime,
-        store::AgentSessionStore,
+        store::{AgentSessionStore, ChatSessionSnapshotStore},
     },
     provider::{CompletionBackend, gemini::GeminiBackend, remote::RemoteBackend},
     session::{ApprovalDecision, SessionRuntime},
     tools::{ProxyBroker, ProxyToolDescriptor, ToolDescriptor, ToolRegistry},
     types::{
         AgentDescriptor, AgentId, AgentKind, ChatMessage, ChatMode, ExternalAgentConfig,
-        ProviderKind,
+        PersistedChatSessionSnapshot, ProviderKind,
     },
 };
 
@@ -27,6 +27,7 @@ struct AiStateInner {
     acp_sessions: RwLock<HashMap<String, AcpSessionHandle>>,
     acp_approvals: RwLock<HashMap<(String, String), oneshot::Sender<ApprovalDecision>>>,
     session_store: AgentSessionStore,
+    chat_session_store: ChatSessionSnapshotStore,
     tools: ToolRegistry,
     proxy_broker: ProxyBroker,
     host: RwLock<Option<Arc<dyn AiHostBindings>>>,
@@ -48,6 +49,7 @@ impl Default for AiState {
                 acp_sessions: RwLock::new(HashMap::new()),
                 acp_approvals: RwLock::new(HashMap::new()),
                 session_store: AgentSessionStore::default(),
+                chat_session_store: ChatSessionSnapshotStore::default(),
                 tools: ToolRegistry::default(),
                 proxy_broker: ProxyBroker::default(),
                 host: RwLock::new(None),
@@ -57,7 +59,7 @@ impl Default for AiState {
 }
 
 impl AiState {
-    pub(crate) fn with_data_dir(data_dir: std::path::PathBuf) -> Self {
+    pub(crate) fn with_data_root(data_root: std::path::PathBuf) -> Self {
         let config = AiConfig::default();
         Self {
             inner: Arc::new(AiStateInner {
@@ -66,7 +68,8 @@ impl AiState {
                 sessions: RwLock::new(HashMap::new()),
                 acp_sessions: RwLock::new(HashMap::new()),
                 acp_approvals: RwLock::new(HashMap::new()),
-                session_store: AgentSessionStore::from_data_dir(data_dir),
+                session_store: AgentSessionStore::from_data_root(data_root.clone()),
+                chat_session_store: ChatSessionSnapshotStore::from_data_root(data_root),
                 tools: ToolRegistry::default(),
                 proxy_broker: ProxyBroker::default(),
                 host: RwLock::new(None),
@@ -94,6 +97,7 @@ impl AiState {
         }
         self.inner.acp_approvals.write().clear();
         self.inner.session_store.clear()?;
+        self.inner.chat_session_store.clear()?;
 
         let config = AiConfig::default();
         *self.inner.config.write() = config;
@@ -105,10 +109,39 @@ impl AiState {
         self.inner.session_store.list()
     }
 
+    pub fn persisted_sessions_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+    ) -> Vec<crate::PersistedAgentSession> {
+        self.inner
+            .session_store
+            .list_for_working_directory(working_directory)
+    }
+
+    pub fn persisted_chat_sessions_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+    ) -> Vec<PersistedChatSessionSnapshot> {
+        self.inner
+            .chat_session_store
+            .list_for_working_directory(working_directory)
+    }
+
+    pub fn replace_persisted_chat_sessions_for_working_directory(
+        &self,
+        working_directory: Option<&str>,
+        sessions: Vec<PersistedChatSessionSnapshot>,
+    ) -> Result<(), AiError> {
+        self.inner
+            .chat_session_store
+            .replace_for_working_directory(working_directory, sessions)
+    }
+
     pub fn record_agent_session(
         &self,
         local_session_id: String,
         agent_id: AgentId,
+        working_directory: Option<String>,
     ) -> Result<(), AiError> {
         let (external_session_id, supports_load, supports_resume) =
             match self.get_acp_session(&local_session_id) {
@@ -128,6 +161,7 @@ impl AiState {
             agent_id,
             supports_load,
             supports_resume,
+            working_directory,
         )
     }
 
@@ -368,6 +402,20 @@ impl AiState {
 
     #[cfg(test)]
     pub(crate) fn with_session_store_path(path: std::path::PathBuf) -> Self {
+        let chat_path = path.with_file_name(format!(
+            "{}.chat.json",
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .unwrap_or("sessions")
+        ));
+        Self::with_store_paths(path, chat_path)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_store_paths(
+        session_store_path: std::path::PathBuf,
+        chat_session_store_path: std::path::PathBuf,
+    ) -> Self {
         let config = AiConfig::default();
         Self {
             inner: Arc::new(AiStateInner {
@@ -376,7 +424,8 @@ impl AiState {
                 sessions: RwLock::new(HashMap::new()),
                 acp_sessions: RwLock::new(HashMap::new()),
                 acp_approvals: RwLock::new(HashMap::new()),
-                session_store: AgentSessionStore::new(path),
+                session_store: AgentSessionStore::new(session_store_path),
+                chat_session_store: ChatSessionSnapshotStore::new(chat_session_store_path),
                 tools: ToolRegistry::default(),
                 proxy_broker: ProxyBroker::default(),
                 host: RwLock::new(None),
@@ -583,7 +632,11 @@ mod agent_runtime_tests {
         let state = AiState::with_session_store_path(path.clone());
 
         state
-            .record_agent_session("local-1".to_string(), AgentId::kuku_native())
+            .record_agent_session(
+                "local-1".to_string(),
+                AgentId::kuku_native(),
+                Some("/Users/me/Notes".to_string()),
+            )
             .unwrap();
         state
             .touch_agent_session("local-1", "Hello from Kuku".to_string())
@@ -594,6 +647,10 @@ mod agent_runtime_tests {
         assert_eq!(sessions[0].local_session_id, "local-1");
         assert_eq!(sessions[0].agent_id, AgentId::kuku_native());
         assert_eq!(sessions[0].title, "Hello from Kuku");
+        assert_eq!(
+            sessions[0].working_directory.as_deref(),
+            Some("/Users/me/Notes")
+        );
 
         let reloaded = AiState::with_session_store_path(path);
         assert_eq!(reloaded.persisted_sessions()[0].local_session_id, "local-1");
@@ -608,7 +665,7 @@ mod agent_runtime_tests {
         let state = AiState::with_session_store_path(path.clone());
 
         state
-            .record_agent_session("local-1".to_string(), AgentId::kuku_native())
+            .record_agent_session("local-1".to_string(), AgentId::kuku_native(), None)
             .unwrap();
 
         state.reset_state().unwrap();
@@ -637,7 +694,11 @@ mod agent_runtime_tests {
             .insert_acp_session("local-1".to_string(), handle)
             .unwrap();
         state
-            .record_agent_session("local-1".to_string(), AgentId("codex-acp".to_string()))
+            .record_agent_session(
+                "local-1".to_string(),
+                AgentId("codex-acp".to_string()),
+                Some("/Users/me/Notes".to_string()),
+            )
             .unwrap();
 
         let sessions = state.persisted_sessions();
@@ -648,6 +709,10 @@ mod agent_runtime_tests {
         );
         assert!(sessions[0].supports_load);
         assert!(!sessions[0].supports_resume);
+        assert_eq!(
+            sessions[0].working_directory.as_deref(),
+            Some("/Users/me/Notes")
+        );
     }
 
     #[test]

--- a/crates/kuku-ai/src/types.rs
+++ b/crates/kuku-ai/src/types.rs
@@ -73,6 +73,31 @@ pub struct PersistedAgentSession {
     pub updated_at_ms: u64,
     pub supports_load: bool,
     pub supports_resume: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedChatSessionSnapshot {
+    pub id: String,
+    pub external_session_id: Option<String>,
+    pub agent_id: AgentId,
+    pub mode: ChatMode,
+    pub created_at: u64,
+    pub updated_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persisted_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_load: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_resume: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub working_directory: Option<String>,
+    pub draft: String,
+    pub auto_approve: bool,
+    #[serde(default)]
+    pub messages: Vec<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## summary
- persist ai chat sessions per vault and restore legacy acp sessions safely
- show acp tool names instead of opaque call ids
- tune final titlebar chrome carried by the layout stack

## notes
- stacked on #4: titlebar and sync layout

## validation
- cargo test --workspace
- pnpm --dir apps/desktop exec vitest run
- pnpm --dir apps/desktop build

## stack
1. ai tool policy and permission foundations
2. vault/editor baseline
3. acp runtime foundation
4. titlebar, sync icon, and layout polish
5. chat session persistence
6. acp mcp policy and chat ux stabilization
