### PR TITLE
fix: stabilize desktop token refresh

### DIFF
--- a/apps/desktop/src-tauri/src/auth.rs
+++ b/apps/desktop/src-tauri/src/auth.rs
@@ -101,6 +101,33 @@ pub fn replace_tokens(tokens: StoredTokens) -> Result<(), TokenError> {
     write_tokens(&tokens)
 }
 
+pub fn replace_tokens_if_refresh_token_matches(
+    expected_refresh_token: &str,
+    tokens: StoredTokens,
+) -> Result<bool, TokenError> {
+    match read_tokens() {
+        Ok(current) if current.refresh_token == expected_refresh_token => {
+            write_tokens(&tokens)?;
+            Ok(true)
+        }
+        Ok(_) | Err(TokenError::NotFound) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+pub fn clear_tokens_if_refresh_token_matches(
+    expected_refresh_token: &str,
+) -> Result<bool, TokenError> {
+    match read_tokens() {
+        Ok(current) if current.refresh_token == expected_refresh_token => {
+            clear_tokens()?;
+            Ok(true)
+        }
+        Ok(_) | Err(TokenError::NotFound) => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
 pub fn read_tokens() -> Result<StoredTokens, TokenError> {
     match secure_storage::read_bytes(&secure_service(), SECURE_ACCOUNT)? {
         Some(content) => serde_json::from_slice(&content)

--- a/apps/desktop/src-tauri/src/auth_commands.rs
+++ b/apps/desktop/src-tauri/src/auth_commands.rs
@@ -1,15 +1,16 @@
 use serde::Serialize;
 use std::{
+    fmt,
     io::{Read, Write},
     net::{TcpListener, TcpStream},
-    sync::mpsc,
+    sync::{OnceLock, mpsc},
     thread,
     time::{Duration, Instant, SystemTime},
 };
 use tauri::{AppHandle, Emitter, command};
 use tauri_plugin_opener::OpenerExt;
 
-use connectrpc::client::CallOptions;
+use connectrpc::{ErrorCode, client::CallOptions};
 use kuku_contract::proto::kuku::auth::v1::{
     DesktopAuthURLRequest, ExchangeDesktopTokenRequest, ProfileRequest, RefreshDesktopTokenRequest,
 };
@@ -17,6 +18,27 @@ use kuku_contract::proto::kuku::auth::v1::{
 use crate::{auth, contract_client};
 
 const DEV_CALLBACK_TIMEOUT: Duration = Duration::from_secs(180);
+static TOKEN_REFRESH_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RefreshMode {
+    IfExpiresSoon,
+    Force,
+}
+
+#[derive(Debug)]
+struct RefreshDesktopTokenError {
+    message: String,
+    clears_auth: bool,
+}
+
+impl fmt::Display for RefreshDesktopTokenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for RefreshDesktopTokenError {}
 
 #[derive(Debug, Serialize)]
 pub struct User {
@@ -75,9 +97,10 @@ pub fn auth_reset() -> Result<(), String> {
 
 #[command]
 pub async fn auth_refresh() -> Result<(), String> {
-    let tokens = auth::read_tokens().map_err(|error| error.to_string())?;
-    let refreshed = refresh_desktop_token(&tokens.refresh_token).await?;
-    auth::replace_tokens(refreshed).map_err(|error| error.to_string())
+    refresh_stored_tokens(RefreshMode::Force)
+        .await?
+        .ok_or_else(|| auth::TokenError::NotFound.to_string())
+        .map(|_| ())
 }
 
 #[command]
@@ -321,21 +344,93 @@ async fn fetch_and_cache_profile() -> Result<(), String> {
     .map_err(|error| format!("failed to cache profile: {error}"))
 }
 
-async fn refresh_desktop_token(refresh_token: &str) -> Result<auth::StoredTokens, String> {
+fn token_refresh_lock() -> &'static tokio::sync::Mutex<()> {
+    TOKEN_REFRESH_LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn read_available_tokens() -> Result<Option<auth::StoredTokens>, String> {
+    match auth::read_tokens() {
+        Ok(tokens) if !tokens.access_token.is_empty() && !tokens.refresh_token.is_empty() => {
+            Ok(Some(tokens))
+        }
+        Ok(_) | Err(auth::TokenError::NotFound) => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+async fn refresh_stored_tokens(mode: RefreshMode) -> Result<Option<auth::StoredTokens>, String> {
+    let Some(observed) = read_available_tokens()? else {
+        return Ok(None);
+    };
+    if mode == RefreshMode::IfExpiresSoon && !auth::token_expires_soon(&observed) {
+        return Ok(Some(observed));
+    }
+
+    let _guard = token_refresh_lock().lock().await;
+    let Some(current) = read_available_tokens()? else {
+        return Ok(None);
+    };
+    if current.refresh_token != observed.refresh_token {
+        return Ok(Some(current));
+    }
+    if mode == RefreshMode::IfExpiresSoon && !auth::token_expires_soon(&current) {
+        return Ok(Some(current));
+    }
+
+    match refresh_desktop_token(&current.refresh_token).await {
+        Ok(refreshed) => {
+            let replaced = auth::replace_tokens_if_refresh_token_matches(
+                &current.refresh_token,
+                refreshed.clone(),
+            )
+            .map_err(|error| error.to_string())?;
+            if replaced {
+                return Ok(Some(refreshed));
+            }
+            read_available_tokens()
+        }
+        Err(error) => {
+            if error.clears_auth {
+                auth::clear_tokens_if_refresh_token_matches(&current.refresh_token)
+                    .map_err(|storage_error| storage_error.to_string())?;
+            }
+            Err(error.to_string())
+        }
+    }
+}
+
+async fn refresh_desktop_token(
+    refresh_token: &str,
+) -> Result<auth::StoredTokens, RefreshDesktopTokenError> {
     let request = RefreshDesktopTokenRequest {
         refresh_token: Some(refresh_token.to_string()),
         ..Default::default()
     };
-    let response = contract_client::auth_service_client()?
+    let response = contract_client::auth_service_client()
+        .map_err(refresh_desktop_token_state_error)?
         .refresh_desktop_token(request)
         .await
-        .map_err(|error| format!("failed to refresh desktop token: {error}"))?
+        .map_err(refresh_desktop_token_error)?
         .into_owned();
     Ok(stored_tokens_from(
         response.access_token,
         response.refresh_token,
         response.expires_in,
     ))
+}
+
+fn refresh_desktop_token_state_error(error: String) -> RefreshDesktopTokenError {
+    RefreshDesktopTokenError {
+        message: error,
+        clears_auth: false,
+    }
+}
+
+fn refresh_desktop_token_error(error: connectrpc::ConnectError) -> RefreshDesktopTokenError {
+    RefreshDesktopTokenError {
+        clears_auth: matches!(error.code, ErrorCode::Unauthenticated),
+        message: format!("failed to refresh desktop token: {error}"),
+    }
 }
 
 fn stored_tokens_from(
@@ -360,15 +455,9 @@ pub async fn authorization_header_for_plugin(plugin_id: &str) -> Result<Option<S
         return Ok(None);
     }
 
-    let mut tokens = match auth::read_tokens() {
-        Ok(tokens) => tokens,
-        Err(auth::TokenError::NotFound) => return Ok(None),
-        Err(error) => return Err(error.to_string()),
+    let Some(tokens) = refresh_stored_tokens(RefreshMode::IfExpiresSoon).await? else {
+        return Ok(None);
     };
-    if auth::token_expires_soon(&tokens) {
-        tokens = refresh_desktop_token(&tokens.refresh_token).await?;
-        auth::replace_tokens(tokens.clone()).map_err(|error| error.to_string())?;
-    }
     if tokens.access_token.is_empty() {
         return Ok(None);
     }
@@ -388,13 +477,9 @@ pub async fn refresh_authorization_header_for_plugin(
         return Ok(None);
     }
 
-    let stored = match auth::read_tokens() {
-        Ok(tokens) => tokens,
-        Err(auth::TokenError::NotFound) => return Ok(None),
-        Err(error) => return Err(error.to_string()),
+    let Some(refreshed) = refresh_stored_tokens(RefreshMode::Force).await? else {
+        return Ok(None);
     };
-    let refreshed = refresh_desktop_token(&stored.refresh_token).await?;
-    auth::replace_tokens(refreshed.clone()).map_err(|error| error.to_string())?;
     if refreshed.access_token.is_empty() {
         return Ok(None);
     }

--- a/apps/desktop/src-tauri/src/sync/client.rs
+++ b/apps/desktop/src-tauri/src/sync/client.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::{fmt, future::Future, pin::Pin, sync::Arc};
+
 use async_trait::async_trait;
 use connectrpc::{ConnectError, ErrorCode, client::CallOptions};
 use kuku_contract::buffa::EnumValue;
@@ -21,6 +23,9 @@ use kuku_contract::proto::kuku::sync::v1::{
 use crate::contract_client;
 
 use super::errors::{SyncError, SyncResult};
+
+pub type RefreshAuthorizationHeader =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = SyncResult<Option<String>>> + Send>> + Send + Sync>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectReservationInput {
@@ -349,9 +354,36 @@ pub trait SyncTransferApi: Send + Sync {
     ) -> SyncResult<Vec<ObjectDownloadTargetDescriptor>>;
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone)]
 pub struct ConnectSyncClient {
-    authorization_header: Option<String>,
+    authorization_header: Arc<parking_lot::Mutex<Option<String>>>,
+    refresh_authorization_header: Option<RefreshAuthorizationHeader>,
+    refresh_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl Default for ConnectSyncClient {
+    fn default() -> Self {
+        Self {
+            authorization_header: Arc::new(parking_lot::Mutex::new(None)),
+            refresh_authorization_header: None,
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+}
+
+impl fmt::Debug for ConnectSyncClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConnectSyncClient")
+            .field(
+                "has_authorization_header",
+                &self.authorization_header.lock().is_some(),
+            )
+            .field(
+                "has_refresh_authorization_header",
+                &self.refresh_authorization_header.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl ConnectSyncClient {
@@ -361,7 +393,9 @@ impl ConnectSyncClient {
 
     pub fn with_authorization_header(header: impl Into<String>) -> Self {
         Self {
-            authorization_header: Some(header.into()),
+            authorization_header: Arc::new(parking_lot::Mutex::new(Some(header.into()))),
+            refresh_authorization_header: None,
+            refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -369,10 +403,63 @@ impl ConnectSyncClient {
         Self::with_authorization_header(format!("Bearer {}", access_token.into()))
     }
 
+    pub fn with_authorization_refresh(
+        mut self,
+        refresh_authorization_header: RefreshAuthorizationHeader,
+    ) -> Self {
+        self.refresh_authorization_header = Some(refresh_authorization_header);
+        self
+    }
+
     fn call_options(&self) -> CallOptions {
-        match &self.authorization_header {
-            Some(header) => CallOptions::default().with_header("authorization", header.clone()),
+        Self::call_options_for(self.authorization_header())
+    }
+
+    fn authorization_header(&self) -> Option<String> {
+        self.authorization_header.lock().clone()
+    }
+
+    fn call_options_for(authorization_header: Option<String>) -> CallOptions {
+        match authorization_header {
+            Some(header) => CallOptions::default().with_header("authorization", header),
             None => CallOptions::default(),
+        }
+    }
+
+    async fn call_with_auth_retry<T, F, Fut>(&self, operation: &str, call: F) -> SyncResult<T>
+    where
+        F: Fn(CallOptions) -> Fut,
+        Fut: Future<Output = Result<T, ConnectError>>,
+    {
+        let attempted_header = self.authorization_header();
+        match call(Self::call_options_for(attempted_header.clone())).await {
+            Ok(response) => Ok(response),
+            Err(error) if error.code == ErrorCode::Unauthenticated => {
+                let Some(refresh_authorization_header) = &self.refresh_authorization_header else {
+                    return Err(sync_rpc_error(operation, error));
+                };
+                let refreshed_header = {
+                    let _guard = self.refresh_lock.lock().await;
+                    let current_header = self.authorization_header();
+                    if current_header != attempted_header {
+                        current_header
+                    } else {
+                        let Some(refreshed_header) = refresh_authorization_header().await? else {
+                            *self.authorization_header.lock() = None;
+                            return Err(SyncError::LoginRequired);
+                        };
+                        *self.authorization_header.lock() = Some(refreshed_header.clone());
+                        Some(refreshed_header)
+                    }
+                };
+                let Some(refreshed_header) = refreshed_header else {
+                    return Err(SyncError::LoginRequired);
+                };
+                call(Self::call_options_for(Some(refreshed_header)))
+                    .await
+                    .map_err(|retry_error| sync_rpc_error(operation, retry_error))
+            }
+            Err(error) => Err(sync_rpc_error(operation, error)),
         }
     }
 }
@@ -398,14 +485,13 @@ fn sync_rpc_error(operation: &str, error: ConnectError) -> SyncError {
 #[async_trait]
 impl SyncSetupApi for ConnectSyncClient {
     async fn get_account_key_state(&self) -> SyncResult<Option<SyncAccountKeyMetadata>> {
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .get_account_key_state_with_options(
-                GetAccountKeyStateRequest::default(),
-                self.call_options(),
-            )
-            .await
-            .map_err(|error| sync_rpc_error("GetAccountKeyState", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let request = GetAccountKeyStateRequest::default();
+        let response = self
+            .call_with_auth_retry("GetAccountKeyState", |options| {
+                client.get_account_key_state_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         response
             .account_key
@@ -428,11 +514,12 @@ impl SyncSetupApi for ConnectSyncClient {
             encrypted_envelope: Some(input.encrypted_envelope),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .create_account_key_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("CreateAccountKey", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("CreateAccountKey", |options| {
+                client.create_account_key_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         let account_key =
             account_key_from_proto(response.account_key.as_option().ok_or_else(|| {
@@ -446,14 +533,13 @@ impl SyncSetupApi for ConnectSyncClient {
     }
 
     async fn list_account_key_envelopes(&self) -> SyncResult<Vec<SyncAccountKeyEnvelopeMetadata>> {
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .list_account_key_envelopes_with_options(
-                ListAccountKeyEnvelopesRequest::default(),
-                self.call_options(),
-            )
-            .await
-            .map_err(|error| sync_rpc_error("ListAccountKeyEnvelopes", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let request = ListAccountKeyEnvelopesRequest::default();
+        let response = self
+            .call_with_auth_retry("ListAccountKeyEnvelopes", |options| {
+                client.list_account_key_envelopes_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         response
             .envelopes
@@ -474,11 +560,12 @@ impl SyncSetupApi for ConnectSyncClient {
             encrypted_envelope: Some(input.encrypted_envelope),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .put_account_key_envelope_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("PutAccountKeyEnvelope", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("PutAccountKeyEnvelope", |options| {
+                client.put_account_key_envelope_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         account_key_envelope_from_proto(response.envelope.as_option().ok_or_else(|| {
             SyncError::Transport("sync response missing account key envelope".into())
@@ -490,11 +577,12 @@ impl SyncSetupApi for ConnectSyncClient {
             crypto_version: Some(crypto_version.to_string()),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .create_workspace_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("CreateWorkspace", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("CreateWorkspace", |options| {
+                client.create_workspace_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         workspace_from_proto(
             response
@@ -505,11 +593,13 @@ impl SyncSetupApi for ConnectSyncClient {
     }
 
     async fn list_workspaces(&self) -> SyncResult<Vec<SyncWorkspaceMetadata>> {
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .list_workspaces_with_options(ListWorkspacesRequest::default(), self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("ListWorkspaces", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let request = ListWorkspacesRequest::default();
+        let response = self
+            .call_with_auth_retry("ListWorkspaces", |options| {
+                client.list_workspaces_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         response
             .workspaces
@@ -523,11 +613,11 @@ impl SyncSetupApi for ConnectSyncClient {
             workspace_id: Some(workspace_id.to_string()),
             ..Default::default()
         };
-        contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .delete_workspace_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("DeleteWorkspace", error))?;
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        self.call_with_auth_retry("DeleteWorkspace", |options| {
+            client.delete_workspace_with_options(request.clone(), options)
+        })
+        .await?;
         Ok(())
     }
 
@@ -542,11 +632,12 @@ impl SyncSetupApi for ConnectSyncClient {
             expected_metadata_version: Some(input.expected_metadata_version),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .update_workspace_metadata_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("UpdateWorkspaceMetadata", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("UpdateWorkspaceMetadata", |options| {
+                client.update_workspace_metadata_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         workspace_from_proto(
             response
@@ -567,11 +658,12 @@ impl SyncSetupApi for ConnectSyncClient {
             expected_workspace_key_version: Some(input.expected_workspace_key_version),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .update_workspace_key_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("UpdateWorkspaceKey", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("UpdateWorkspaceKey", |options| {
+                client.update_workspace_key_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         workspace_from_proto(
             response
@@ -595,11 +687,12 @@ impl SyncSetupApi for ConnectSyncClient {
             encrypted_device_name: Some(encrypted_device_name),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .register_device_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("RegisterDevice", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("RegisterDevice", |options| {
+                client.register_device_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         device_from_proto(
             response
@@ -624,11 +717,12 @@ impl SyncSetupApi for ConnectSyncClient {
             created_by_device_id: Some(input.created_by_device_id),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .put_key_envelope_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("PutKeyEnvelope", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("PutKeyEnvelope", |options| {
+                client.put_key_envelope_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         key_envelope_from_proto(
             response
@@ -646,11 +740,12 @@ impl SyncSetupApi for ConnectSyncClient {
             workspace_id: Some(workspace_id.to_string()),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .list_key_envelopes_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("ListKeyEnvelopes", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("ListKeyEnvelopes", |options| {
+                client.list_key_envelopes_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         response
             .envelopes
@@ -671,11 +766,12 @@ impl SyncSetupApi for ConnectSyncClient {
             expected_metadata_version: Some(input.expected_metadata_version),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .update_device_metadata_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("UpdateDeviceMetadata", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("UpdateDeviceMetadata", |options| {
+                client.update_device_metadata_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         device_from_proto(
             response
@@ -693,11 +789,12 @@ impl SyncCommitApi for ConnectSyncClient {
             workspace_id: Some(workspace_id.to_string()),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .get_head_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("GetHead", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("GetHead", |options| {
+                client.get_head_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         Ok(SyncHead {
             current_head_commit_id: response.current_head_commit_id.unwrap_or_default(),
@@ -718,11 +815,12 @@ impl SyncCommitApi for ConnectSyncClient {
             page_size: Some(page_size),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .list_commits_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("ListCommits", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("ListCommits", |options| {
+                client.list_commits_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         Ok(ListCommitsOutput {
             commits: response
@@ -751,11 +849,12 @@ impl SyncCommitApi for ConnectSyncClient {
             signature: Some(input.signature),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .publish_commit_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("PublishCommit", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("PublishCommit", |options| {
+                client.publish_commit_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
         let commit = response
             .commit
@@ -790,11 +889,12 @@ impl SyncTransferApi for ConnectSyncClient {
                 .collect(),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .reserve_object_ids_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("ReserveObjectIds", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("ReserveObjectIds", |options| {
+                client.reserve_object_ids_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
 
         response
@@ -827,11 +927,12 @@ impl SyncTransferApi for ConnectSyncClient {
                 .collect(),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .create_object_upload_batch_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("CreateObjectUploadBatch", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("CreateObjectUploadBatch", |options| {
+                client.create_object_upload_batch_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
 
         response
@@ -864,11 +965,12 @@ impl SyncTransferApi for ConnectSyncClient {
                 .collect(),
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .complete_object_upload_batch_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("CompleteObjectUploadBatch", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("CompleteObjectUploadBatch", |options| {
+                client.complete_object_upload_batch_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
 
         response
@@ -890,11 +992,12 @@ impl SyncTransferApi for ConnectSyncClient {
             object_ids,
             ..Default::default()
         };
-        let response = contract_client::sync_service_client()
-            .map_err(SyncError::Transport)?
-            .create_object_download_batch_with_options(request, self.call_options())
-            .await
-            .map_err(|error| sync_rpc_error("CreateObjectDownloadBatch", error))?
+        let client = contract_client::sync_service_client().map_err(SyncError::Transport)?;
+        let response = self
+            .call_with_auth_retry("CreateObjectDownloadBatch", |options| {
+                client.create_object_download_batch_with_options(request.clone(), options)
+            })
+            .await?
             .into_owned();
 
         response
@@ -1085,7 +1188,229 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+    use tokio::runtime::Builder;
+    use tokio::sync::Barrier;
+
+    #[test]
+    fn call_with_auth_retry_refreshes_after_unauthenticated() {
+        block_on(async {
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshes_for_callback = refreshes.clone();
+            let client = ConnectSyncClient::with_authorization_header("Bearer stale")
+                .with_authorization_refresh(Arc::new(move || {
+                    let refreshes = refreshes_for_callback.clone();
+                    Box::pin(async move {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        Ok(Some("Bearer fresh".to_string()))
+                    })
+                }));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_for_rpc = calls.clone();
+
+            let result = client
+                .call_with_auth_retry("GetHead", move |_options| {
+                    let calls = calls_for_rpc.clone();
+                    async move {
+                        let attempt = calls.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 0 {
+                            Err(ConnectError::new(
+                                ErrorCode::Unauthenticated,
+                                "not authenticated",
+                            ))
+                        } else {
+                            Ok("ok")
+                        }
+                    }
+                })
+                .await;
+
+            assert_eq!(result.expect("retry should succeed"), "ok");
+            assert_eq!(calls.load(Ordering::SeqCst), 2);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                client.authorization_header.lock().as_deref(),
+                Some("Bearer fresh")
+            );
+        });
+    }
+
+    #[test]
+    fn call_with_auth_retry_clears_header_when_refresh_returns_none() {
+        block_on(async {
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshes_for_callback = refreshes.clone();
+            let client = ConnectSyncClient::with_authorization_header("Bearer stale")
+                .with_authorization_refresh(Arc::new(move || {
+                    let refreshes = refreshes_for_callback.clone();
+                    Box::pin(async move {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        Ok(None)
+                    })
+                }));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_for_rpc = calls.clone();
+
+            let result = client
+                .call_with_auth_retry("GetHead", move |_options| {
+                    let calls = calls_for_rpc.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), _>(ConnectError::new(
+                            ErrorCode::Unauthenticated,
+                            "not authenticated",
+                        ))
+                    }
+                })
+                .await;
+
+            assert!(matches!(result, Err(SyncError::LoginRequired)));
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            assert_eq!(client.authorization_header.lock().as_deref(), None);
+        });
+    }
+
+    #[test]
+    fn call_with_auth_retry_returns_refresh_error_without_retry() {
+        block_on(async {
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshes_for_callback = refreshes.clone();
+            let client = ConnectSyncClient::with_authorization_header("Bearer stale")
+                .with_authorization_refresh(Arc::new(move || {
+                    let refreshes = refreshes_for_callback.clone();
+                    Box::pin(async move {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        Err(SyncError::Transport("refresh failed".into()))
+                    })
+                }));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_for_rpc = calls.clone();
+
+            let result = client
+                .call_with_auth_retry("GetHead", move |_options| {
+                    let calls = calls_for_rpc.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), _>(ConnectError::new(
+                            ErrorCode::Unauthenticated,
+                            "not authenticated",
+                        ))
+                    }
+                })
+                .await;
+
+            assert!(
+                matches!(result, Err(SyncError::Transport(message)) if message == "refresh failed")
+            );
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                client.authorization_header.lock().as_deref(),
+                Some("Bearer stale")
+            );
+        });
+    }
+
+    #[test]
+    fn call_with_auth_retry_maps_unauthenticated_retry_to_login_required() {
+        block_on(async {
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshes_for_callback = refreshes.clone();
+            let client = ConnectSyncClient::with_authorization_header("Bearer stale")
+                .with_authorization_refresh(Arc::new(move || {
+                    let refreshes = refreshes_for_callback.clone();
+                    Box::pin(async move {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        Ok(Some("Bearer fresh".to_string()))
+                    })
+                }));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let calls_for_rpc = calls.clone();
+
+            let result = client
+                .call_with_auth_retry("GetHead", move |_options| {
+                    let calls = calls_for_rpc.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), _>(ConnectError::new(
+                            ErrorCode::Unauthenticated,
+                            "not authenticated",
+                        ))
+                    }
+                })
+                .await;
+
+            assert!(matches!(result, Err(SyncError::LoginRequired)));
+            assert_eq!(calls.load(Ordering::SeqCst), 2);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                client.authorization_header.lock().as_deref(),
+                Some("Bearer fresh")
+            );
+        });
+    }
+
+    #[test]
+    fn call_with_auth_retry_coalesces_concurrent_refreshes() {
+        block_on(async {
+            let refreshes = Arc::new(AtomicUsize::new(0));
+            let refreshes_for_callback = refreshes.clone();
+            let client = ConnectSyncClient::with_authorization_header("Bearer stale")
+                .with_authorization_refresh(Arc::new(move || {
+                    let refreshes = refreshes_for_callback.clone();
+                    Box::pin(async move {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        Ok(Some("Bearer fresh".to_string()))
+                    })
+                }));
+            let first_attempts = Arc::new(AtomicUsize::new(0));
+            let calls = Arc::new(AtomicUsize::new(0));
+            let barrier = Arc::new(Barrier::new(2));
+            let make_rpc = |first_attempts: Arc<AtomicUsize>,
+                            calls: Arc<AtomicUsize>,
+                            barrier: Arc<Barrier>| {
+                move |_options| {
+                    let first_attempts = first_attempts.clone();
+                    let calls = calls.clone();
+                    let barrier = barrier.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        if first_attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                            barrier.wait().await;
+                            Err(ConnectError::new(
+                                ErrorCode::Unauthenticated,
+                                "not authenticated",
+                            ))
+                        } else {
+                            Ok(())
+                        }
+                    }
+                }
+            };
+
+            let first = client.call_with_auth_retry(
+                "GetHead",
+                make_rpc(first_attempts.clone(), calls.clone(), barrier.clone()),
+            );
+            let second = client.call_with_auth_retry(
+                "GetHead",
+                make_rpc(first_attempts.clone(), calls.clone(), barrier.clone()),
+            );
+            let (first, second) = tokio::join!(first, second);
+
+            assert!(first.is_ok());
+            assert!(second.is_ok());
+            assert_eq!(calls.load(Ordering::SeqCst), 4);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                client.authorization_header.lock().as_deref(),
+                Some("Bearer fresh")
+            );
+        });
+    }
 
     #[test]
     fn sync_rpc_error_maps_connect_codes_to_sync_errors() {
@@ -1124,5 +1449,13 @@ mod tests {
             ),
             SyncError::Offline(_)
         ));
+    }
+
+    fn block_on<T>(future: impl std::future::Future<Output = T>) -> T {
+        Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build tokio runtime")
+            .block_on(future)
     }
 }

--- a/apps/desktop/src-tauri/src/sync/commands.rs
+++ b/apps/desktop/src-tauri/src/sync/commands.rs
@@ -25,14 +25,15 @@ use super::checkpoint::{
     CRYPTO_VERSION, PushLocalChangesInput, PushMergeCommitInput, SyncPushPipeline,
 };
 use super::client::{
-    ConnectSyncClient, CreateAccountKeyInput, SyncAccountKeyEnvelopeMetadata, SyncCommitApi,
-    SyncHead, SyncSetupApi, SyncTransferApi, SyncWorkspaceMetadata, UpdateDeviceMetadataInput,
-    UpdateWorkspaceKeyInput, UpdateWorkspaceMetadataInput,
+    ConnectSyncClient, CreateAccountKeyInput, RefreshAuthorizationHeader,
+    SyncAccountKeyEnvelopeMetadata, SyncCommitApi, SyncHead, SyncSetupApi, SyncTransferApi,
+    SyncWorkspaceMetadata, UpdateDeviceMetadataInput, UpdateWorkspaceKeyInput,
+    UpdateWorkspaceMetadataInput,
 };
 use super::crypto::SymmetricKey;
 use super::db::{self, SyncVaultRecord};
 use super::errors::command_error;
-use super::errors::{SyncCommandError, SyncError, SyncResult};
+use super::errors::{SyncCommandError, SyncError, SyncErrorCategory, SyncResult};
 use super::keys;
 use super::planner::PlannerConfig;
 use super::scanner::{ScannedFile, normalize_vault_relative_path, scan_vault};
@@ -413,7 +414,7 @@ impl TransferProgressSink for RuntimeTransferProgressSink {
 async fn probe_sync_config(mut config: SyncVaultConfig) -> SyncResult<SyncConfigProbe> {
     validate_config_for_command(&config)?;
     let authorization = authorization_header().await?;
-    let client = Arc::new(ConnectSyncClient::with_authorization_header(authorization));
+    let client = Arc::new(connect_sync_client(authorization));
 
     let workspace_id = config.remote_workspace_id.trim().to_string();
     let local_vault = if workspace_id.is_empty() {
@@ -665,7 +666,7 @@ async fn unlock_existing_account_key(
 
 async fn get_account_recovery_state() -> SyncResult<SyncAccountRecoveryState> {
     let authorization = authorization_header().await?;
-    let client = ConnectSyncClient::with_authorization_header(authorization);
+    let client = connect_sync_client(authorization);
     let Some(account_key) = client.get_account_key_state().await? else {
         return Ok(SyncAccountRecoveryState::default());
     };
@@ -783,7 +784,7 @@ async fn list_account_workspaces(
     recovery_phrase: Option<&str>,
 ) -> SyncResult<Vec<SyncWorkspaceSummary>> {
     let authorization = authorization_header().await?;
-    let client = Arc::new(ConnectSyncClient::with_authorization_header(authorization));
+    let client = Arc::new(connect_sync_client(authorization));
     let Some(account) = unlock_existing_account_key(&client, recovery_phrase).await? else {
         return Ok(Vec::new());
     };
@@ -800,7 +801,7 @@ async fn create_account_workspace(
     current_workspace_id: Option<&str>,
 ) -> SyncResult<SyncWorkspaceSummary> {
     let authorization = authorization_header().await?;
-    let client = Arc::new(ConnectSyncClient::with_authorization_header(authorization));
+    let client = Arc::new(connect_sync_client(authorization));
     let account_config = SyncVaultConfig {
         vault_id: String::new(),
         root_path: String::new(),
@@ -840,7 +841,7 @@ async fn rename_account_workspace(
     let workspace_id = normalized_workspace_id(&request.workspace_id)?;
     let workspace_name = normalized_workspace_name(&request.name)?;
     let authorization = authorization_header().await?;
-    let client = Arc::new(ConnectSyncClient::with_authorization_header(authorization));
+    let client = Arc::new(connect_sync_client(authorization));
     let account = unlock_existing_account_key(&client, request.passphrase.as_deref())
         .await?
         .ok_or(SyncError::NotConfigured)?;
@@ -868,13 +869,13 @@ async fn rename_account_workspace(
 
 async fn delete_account_workspace(workspace_id: &str) -> SyncResult<()> {
     let authorization = authorization_header().await?;
-    let client = ConnectSyncClient::with_authorization_header(authorization);
+    let client = connect_sync_client(authorization);
     client.delete_workspace(workspace_id).await
 }
 
 async fn current_workspace_exists_for_account(workspace_id: &str) -> SyncResult<bool> {
     let authorization = authorization_header().await?;
-    let client = ConnectSyncClient::with_authorization_header(authorization);
+    let client = connect_sync_client(authorization);
     Ok(client
         .list_workspaces()
         .await?
@@ -1488,7 +1489,7 @@ fn sync_client_and_queue(
     run_id: u64,
     authorization: String,
 ) -> SyncResult<(Arc<ConnectSyncClient>, ObjectTransferQueue)> {
-    let client = Arc::new(ConnectSyncClient::with_authorization_header(authorization));
+    let client = Arc::new(connect_sync_client(authorization));
     let transfer_api: Arc<dyn SyncTransferApi> = client.clone();
     let queue = ObjectTransferQueue::new(
         transfer_api,
@@ -1502,6 +1503,30 @@ fn sync_client_and_queue(
     Ok((client, queue))
 }
 
+fn connect_sync_client(authorization: String) -> ConnectSyncClient {
+    ConnectSyncClient::with_authorization_header(authorization)
+        .with_authorization_refresh(sync_refresh_authorization_header())
+}
+
+fn sync_refresh_authorization_header() -> RefreshAuthorizationHeader {
+    Arc::new(|| {
+        Box::pin(async {
+            auth_commands::refresh_authorization_header_for_plugin(CORE_SYNC_PLUGIN_ID)
+                .await
+                .map_err(map_auth_header_error)
+        })
+    })
+}
+
+fn map_auth_header_error(error: String) -> SyncError {
+    let transport = SyncError::Transport(error);
+    if transport.category() == SyncErrorCategory::LoginRequired {
+        SyncError::LoginRequired
+    } else {
+        transport
+    }
+}
+
 async fn authorization_header() -> SyncResult<String> {
     let authorized = auth::is_plugin_authorized(CORE_SYNC_PLUGIN_ID)
         .map_err(|error| SyncError::Transport(error.to_string()))?;
@@ -1510,7 +1535,7 @@ async fn authorization_header() -> SyncResult<String> {
     }
     auth_commands::authorization_header_for_plugin(CORE_SYNC_PLUGIN_ID)
         .await
-        .map_err(SyncError::Transport)?
+        .map_err(map_auth_header_error)?
         .ok_or(SyncError::LoginRequired)
 }
 
@@ -1730,7 +1755,7 @@ async fn get_remote_status_for_state(status: &SyncRuntimeStatus) -> SyncResult<S
         required_status_value(status.remote_workspace_id.as_deref(), "remote_workspace_id")?
             .to_string();
     let authorization = authorization_header().await?;
-    let client = ConnectSyncClient::with_authorization_header(authorization);
+    let client = connect_sync_client(authorization);
     let head = client.get_head(&workspace_id).await?;
     let local_vault = match status.vault_id.as_deref() {
         Some(vault_id) => {

--- a/apps/desktop/src-tauri/src/sync/transfer.rs
+++ b/apps/desktop/src-tauri/src/sync/transfer.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use tokio::sync::Semaphore;
 
 use super::client::{
-    CompletedObjectUploadDescriptor, ConnectSyncClient, HttpHeader, ObjectDownloadTargetDescriptor,
+    CompletedObjectUploadDescriptor, HttpHeader, ObjectDownloadTargetDescriptor,
     ObjectReservationInput, ObjectUploadCompletion, ObjectUploadDescriptor,
     ObjectUploadTargetDescriptor, SyncTransferApi, UploadedObjectMetadata,
 };
@@ -227,18 +227,6 @@ impl ObjectTransferQueue {
             config,
             progress_sink: None,
         })
-    }
-
-    pub fn connect(authorization_header: Option<String>) -> SyncResult<Self> {
-        let api: Arc<dyn SyncTransferApi> = match authorization_header {
-            Some(header) => Arc::new(ConnectSyncClient::with_authorization_header(header)),
-            None => Arc::new(ConnectSyncClient::new()),
-        };
-        Self::new(
-            api,
-            Arc::new(ReqwestObjectTransferHttp::new()),
-            TransferQueueConfig::default(),
-        )
     }
 
     pub fn with_progress_sink(mut self, progress_sink: Arc<dyn TransferProgressSink>) -> Self {

--- a/apps/desktop/src/plugins/builtin/core_auth/auth_service.test.ts
+++ b/apps/desktop/src/plugins/builtin/core_auth/auth_service.test.ts
@@ -84,6 +84,34 @@ describe("core_auth auth_service", () => {
     expect(auth.authState.error).toBeNull();
   });
 
+  it("marks the session signed out when refresh clears stored tokens", async () => {
+    let statusChecks = 0;
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "auth_check_status":
+          statusChecks += 1;
+          return statusChecks <= 2;
+        case "auth_get_user":
+          return { email: "kuku@example.com" };
+        case "auth_list_plugin_authorizations":
+          return [{ pluginId: "ai-chat", authorized: true }];
+        case "auth_refresh":
+          throw new Error("failed to refresh desktop token: invalid token");
+        default:
+          throw new Error(`unexpected invoke: ${command}`);
+      }
+    });
+
+    const auth = await loadAuthServiceModule();
+    const service = await auth.createAuthService();
+
+    await service.refresh();
+
+    expect(auth.authState.authenticated).toBe(false);
+    expect(auth.authState.user).toBeNull();
+    expect(auth.authState.error).toBe("failed to refresh desktop token: invalid token");
+  });
+
   it("opens the account dashboard in the browser", async () => {
     mockInvoke.mockImplementation(async (command: string) => {
       switch (command) {

--- a/apps/server/internal/auth/service.go
+++ b/apps/server/internal/auth/service.go
@@ -405,28 +405,30 @@ func (s *AuthService) RefreshDesktopTokens(ctx context.Context, refreshToken, ip
 }
 
 func (s *AuthService) refreshTokens(ctx context.Context, refreshToken, ipAddress, userAgent string, accessTTL, refreshTTL time.Duration) (*TokenPair, error) {
-	row, err := s.queries.GetRefreshTokenByHash(ctx, hashToken(refreshToken))
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrInvalidToken
+	var user sqlc.AuthUser
+	var pair *TokenPair
+	if err := s.withTx(ctx, func(q *sqlc.Queries) error {
+		row, err := q.ConsumeRefreshTokenByHash(ctx, sqlc.ConsumeRefreshTokenByHashParams{
+			TokenHash:         hashToken(refreshToken),
+			InactivityTimeout: database.Interval(s.cfg.SessionInactivity),
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrInvalidToken
+			}
+			return err
 		}
-		return nil, err
-	}
-	if !row.ExpiresAt.Valid || row.ExpiresAt.Time.Before(time.Now()) {
-		return nil, ErrTokenExpired
-	}
-	user, err := s.queries.GetUserByID(ctx, row.UserID)
-	if err != nil {
-		return nil, err
-	}
-	if err := s.queries.RevokeRefreshToken(ctx, row.ID); err != nil {
-		return nil, err
-	}
-	if err := s.queries.UpdateSessionRefreshedAt(ctx, row.SessionID); err != nil {
-		return nil, err
-	}
-	pair, err := s.createTokens(ctx, user, row.SessionID, accessTTL, refreshTTL)
-	if err != nil {
+
+		user, err = q.GetUserByID(ctx, row.UserID)
+		if err != nil {
+			return err
+		}
+		if err := q.UpdateSessionRefreshedAt(ctx, row.SessionID); err != nil {
+			return err
+		}
+		pair, err = s.createTokensWithQueries(ctx, q, user, row.SessionID, accessTTL, refreshTTL)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	_ = s.logAuthEvent(ctx, user.ID, user.Email, sqlc.AuditLogAuthActionTokenRefreshed, nil, ipAddress, userAgent)
@@ -698,10 +700,10 @@ func (s *AuthService) createSessionAndTokens(ctx context.Context, user sqlc.Auth
 	if err != nil {
 		return nil, err
 	}
-	return s.createTokens(ctx, user, session.ID, accessTTL, refreshTTL)
+	return s.createTokensWithQueries(ctx, s.queries, user, session.ID, accessTTL, refreshTTL)
 }
 
-func (s *AuthService) createTokens(ctx context.Context, user sqlc.AuthUser, sessionID uuid.UUID, accessTTL, refreshTTL time.Duration) (*TokenPair, error) {
+func (s *AuthService) createTokensWithQueries(ctx context.Context, q *sqlc.Queries, user sqlc.AuthUser, sessionID uuid.UUID, accessTTL, refreshTTL time.Duration) (*TokenPair, error) {
 	userID := user.ID
 	now := time.Now()
 	claims := &Claims{
@@ -718,7 +720,7 @@ func (s *AuthService) createTokens(ctx context.Context, user sqlc.AuthUser, sess
 		return nil, err
 	}
 	refreshToken := generateSecureToken(32)
-	_, err = s.queries.CreateRefreshToken(ctx, sqlc.CreateRefreshTokenParams{
+	_, err = q.CreateRefreshToken(ctx, sqlc.CreateRefreshTokenParams{
 		TokenHash: hashToken(refreshToken),
 		SessionID: sessionID,
 		UserID:    user.ID,

--- a/apps/server/internal/auth/service_integration_test.go
+++ b/apps/server/internal/auth/service_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +26,127 @@ type noopEmailSender struct{}
 
 func (noopEmailSender) SendAuthCode(context.Context, string, string) error {
 	return nil
+}
+
+func TestAuthRefreshTokensConsumesRefreshTokenAtomically(t *testing.T) {
+	databaseURL := os.Getenv("KUKU_TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("KUKU_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := database.NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	migrationsDir := filepath.Join("..", "..", "sql", "migrations")
+	if err := database.RunMigrations(ctx, pool, migrationsDir); err != nil {
+		t.Fatal(err)
+	}
+	queries := sqlc.New(pool)
+	user, err := queries.CreateUser(ctx, sqlc.CreateUserParams{
+		Email:            "auth-refresh-race-" + uuid.NewString() + "@example.com",
+		Name:             "Auth Refresh Race Test",
+		EmailConfirmedAt: database.Timestamptz(time.Now().UTC()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewAuthService(&config.Config{
+		JWTSecret:         "test-refresh-secret",
+		SessionMaxAge:     time.Hour,
+		SessionInactivity: time.Hour,
+	}, pool, queries, noopEmailSender{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	initial, err := service.createSessionAndTokens(ctx, user, "test", "127.0.0.1", desktopAccessExpiry, desktopRefreshExpiry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const attempts = 8
+	start := make(chan struct{})
+	successes := make(chan *TokenPair, attempts)
+	failures := make(chan error, attempts)
+	var wg sync.WaitGroup
+	for range attempts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			pair, err := service.RefreshDesktopTokens(ctx, initial.RefreshToken, "127.0.0.1", "test")
+			if err != nil {
+				failures <- err
+				return
+			}
+			successes <- pair
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(successes)
+	close(failures)
+
+	successCount := 0
+	for pair := range successes {
+		successCount++
+		if pair.RefreshToken == "" || pair.RefreshToken == initial.RefreshToken {
+			t.Fatalf("refresh token = %q, want a new non-empty token", pair.RefreshToken)
+		}
+	}
+	invalidCount := 0
+	for err := range failures {
+		if !errors.Is(err, ErrInvalidToken) {
+			t.Fatalf("refresh error = %v, want ErrInvalidToken", err)
+		}
+		invalidCount++
+	}
+	if successCount != 1 {
+		t.Fatalf("successful refreshes = %d, want 1", successCount)
+	}
+	if invalidCount != attempts-1 {
+		t.Fatalf("invalid refreshes = %d, want %d", invalidCount, attempts-1)
+	}
+}
+
+func TestAuthRefreshTokensRejectsExpiredSession(t *testing.T) {
+	databaseURL := os.Getenv("KUKU_TEST_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("KUKU_TEST_DATABASE_URL is not set")
+	}
+
+	ctx := context.Background()
+	pool, err := database.NewPool(ctx, databaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	migrationsDir := filepath.Join("..", "..", "sql", "migrations")
+	if err := database.RunMigrations(ctx, pool, migrationsDir); err != nil {
+		t.Fatal(err)
+	}
+	queries := sqlc.New(pool)
+	user, err := queries.CreateUser(ctx, sqlc.CreateUserParams{
+		Email:            "auth-refresh-expired-session-" + uuid.NewString() + "@example.com",
+		Name:             "Auth Refresh Expired Session Test",
+		EmailConfirmedAt: database.Timestamptz(time.Now().UTC()),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := NewAuthService(&config.Config{
+		JWTSecret:         "test-refresh-secret",
+		SessionMaxAge:     -time.Minute,
+		SessionInactivity: time.Hour,
+	}, pool, queries, noopEmailSender{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	initial, err := service.createSessionAndTokens(ctx, user, "test", "127.0.0.1", desktopAccessExpiry, desktopRefreshExpiry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RefreshDesktopTokens(ctx, initial.RefreshToken, "127.0.0.1", "test"); !errors.Is(err, ErrInvalidToken) {
+		t.Fatalf("RefreshDesktopTokens error = %v, want ErrInvalidToken", err)
+	}
 }
 
 func TestAuthDeleteAccountMarksSyncDataForDeferredCleanup(t *testing.T) {

--- a/apps/server/internal/database/sqlc/auth.sql.go
+++ b/apps/server/internal/database/sqlc/auth.sql.go
@@ -43,6 +43,41 @@ func (q *Queries) ConsumeOneTimeToken(ctx context.Context, tokenHash string) (Au
 	return i, err
 }
 
+const consumeRefreshTokenByHash = `-- name: ConsumeRefreshTokenByHash :one
+UPDATE auth.refresh_tokens AS rt
+SET revoked_at = now(), updated_at = now()
+FROM auth.sessions AS s
+WHERE rt.session_id = s.id
+  AND rt.token_hash = $1
+  AND rt.revoked_at IS NULL
+  AND rt.expires_at > now()
+  AND s.revoked_at IS NULL
+  AND s.not_after > now()
+  AND s.refreshed_at > now() - $2::interval
+RETURNING rt.id, rt.token_hash, rt.session_id, rt.user_id, rt.expires_at, rt.revoked_at, rt.created_at, rt.updated_at
+`
+
+type ConsumeRefreshTokenByHashParams struct {
+	TokenHash         string          `json:"token_hash"`
+	InactivityTimeout pgtype.Interval `json:"inactivity_timeout"`
+}
+
+func (q *Queries) ConsumeRefreshTokenByHash(ctx context.Context, arg ConsumeRefreshTokenByHashParams) (AuthRefreshToken, error) {
+	row := q.db.QueryRow(ctx, consumeRefreshTokenByHash, arg.TokenHash, arg.InactivityTimeout)
+	var i AuthRefreshToken
+	err := row.Scan(
+		&i.ID,
+		&i.TokenHash,
+		&i.SessionID,
+		&i.UserID,
+		&i.ExpiresAt,
+		&i.RevokedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const createAuthEvent = `-- name: CreateAuthEvent :exec
 INSERT INTO audit_log.auth_events (actor_id, actor_email, action, payload, ip_address, user_agent)
 VALUES ($1, $2, $3, $4, $5, $6)
@@ -337,29 +372,6 @@ func (q *Queries) GetIdentityByProviderID(ctx context.Context, arg GetIdentityBy
 		&i.IdentityData,
 		&i.Email,
 		&i.LastSignInAt,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
-const getRefreshTokenByHash = `-- name: GetRefreshTokenByHash :one
-SELECT id, token_hash, session_id, user_id, expires_at, revoked_at, created_at, updated_at FROM auth.refresh_tokens
-WHERE token_hash = $1
-  AND revoked_at IS NULL
-  AND expires_at > now()
-`
-
-func (q *Queries) GetRefreshTokenByHash(ctx context.Context, tokenHash string) (AuthRefreshToken, error) {
-	row := q.db.QueryRow(ctx, getRefreshTokenByHash, tokenHash)
-	var i AuthRefreshToken
-	err := row.Scan(
-		&i.ID,
-		&i.TokenHash,
-		&i.SessionID,
-		&i.UserID,
-		&i.ExpiresAt,
-		&i.RevokedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/apps/server/internal/database/sqlc/querier.go
+++ b/apps/server/internal/database/sqlc/querier.go
@@ -24,6 +24,7 @@ type Querier interface {
 	// winner gets a non-empty result. A second caller (or a stale/used token)
 	// gets pgx.ErrNoRows.
 	ConsumeOneTimeToken(ctx context.Context, tokenHash string) (AuthOneTimeToken, error)
+	ConsumeRefreshTokenByHash(ctx context.Context, arg ConsumeRefreshTokenByHashParams) (AuthRefreshToken, error)
 	CountActiveSyncWorkspacesByOwner(ctx context.Context, ownerUserID uuid.UUID) (int32, error)
 	CreateAuthEvent(ctx context.Context, arg CreateAuthEventParams) error
 	CreateFlowState(ctx context.Context, arg CreateFlowStateParams) (AuthFlowState, error)
@@ -49,7 +50,6 @@ type Querier interface {
 	GetIdentityByProviderID(ctx context.Context, arg GetIdentityByProviderIDParams) (AuthIdentity, error)
 	GetLatestSyncCheckpointCommit(ctx context.Context, workspaceID uuid.UUID) (KukuSyncCommit, error)
 	GetLatestSyncCheckpointCommitID(ctx context.Context, workspaceID uuid.UUID) (string, error)
-	GetRefreshTokenByHash(ctx context.Context, tokenHash string) (AuthRefreshToken, error)
 	GetSubscriptionByUserID(ctx context.Context, userID uuid.UUID) (KukuSubscription, error)
 	GetSubscriptionByUserIDForUpdate(ctx context.Context, userID uuid.UUID) (KukuSubscription, error)
 	GetSyncAccountKeyByUser(ctx context.Context, userID uuid.UUID) (KukuSyncAccountKey, error)

--- a/apps/server/sql/queries/auth.sql
+++ b/apps/server/sql/queries/auth.sql
@@ -73,11 +73,18 @@ INSERT INTO auth.refresh_tokens (token_hash, session_id, user_id, expires_at)
 VALUES ($1, $2, $3, $4)
 RETURNING *;
 
--- name: GetRefreshTokenByHash :one
-SELECT * FROM auth.refresh_tokens
-WHERE token_hash = $1
-  AND revoked_at IS NULL
-  AND expires_at > now();
+-- name: ConsumeRefreshTokenByHash :one
+UPDATE auth.refresh_tokens AS rt
+SET revoked_at = now(), updated_at = now()
+FROM auth.sessions AS s
+WHERE rt.session_id = s.id
+  AND rt.token_hash = $1
+  AND rt.revoked_at IS NULL
+  AND rt.expires_at > now()
+  AND s.revoked_at IS NULL
+  AND s.not_after > now()
+  AND s.refreshed_at > now() - sqlc.arg('inactivity_timeout')::interval
+RETURNING rt.*;
 
 -- name: RevokeRefreshToken :exec
 UPDATE auth.refresh_tokens


### PR DESCRIPTION
## summary
- atomically consume refresh tokens on the server to prevent concurrent refresh races
- serialize desktop token refresh and only replace/clear stored tokens when the observed refresh token still matches
- make sync RPCs retry once after a 401 by forcing a desktop auth refresh
- coalesce concurrent sync refresh retries and add failure-path coverage