### PR TITLE
feat: rebuild 3D graph renderer as infinite-universe star map

### DIFF
--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
@@ -49,7 +49,8 @@ import {
   SphereGeometry,
 } from "three";
 
-import { t, tf } from "~/i18n";
+import { currentLocale, t, tf } from "~/i18n";
+import { settingsState } from "~/stores/settings";
 import { getEffectiveTheme } from "~/stores/theme";
 
 import { graphAnimationReplayRevision } from "./graph_animation";
@@ -123,6 +124,7 @@ const GALAXY_INITIAL_CAMERA: CameraPoint = { x: 0, y: -300, z: 440 };
 const STAR_SIZE_BASE = 7.5;
 /** Hubs with at least this many links get diffraction spikes. */
 const STAR_SPIKE_MIN_LINKS = 5;
+const LABEL_FONT_FALLBACK = '"Goorm Sans", -apple-system, BlinkMacSystemFont, sans-serif';
 
 /**
  * Invisible raycast proxy shared by every node: hover/click picking needs a
@@ -163,7 +165,7 @@ const STARFIELD_FRAGMENT = /* glsl */ `
 
   void main() {
     float dist = length(gl_PointCoord - 0.5);
-    float alpha = smoothstep(0.5, 0.08, dist);
+    float alpha = 1.0 - smoothstep(0.08, 0.5, dist);
     gl_FragColor = vec4(vColor, alpha * vAlpha * uOpacity);
   }
 `;
@@ -389,10 +391,12 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   let graphEl: Graph3D | undefined;
   let resizeObs: ResizeObserver | undefined;
   let cameraAnimationFrame: number | undefined;
+  let zoomFrame: number | undefined;
   let isCameraAnimating = false;
   let pendingHoveredNode: FGNode | null | undefined;
   let hoverFrame: number | undefined;
   let lastHugeHoverAt = 0;
+  let removeControlsChangeListener: (() => void) | undefined;
 
   const cssVarCache = new Map<string, string>();
 
@@ -421,6 +425,10 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     const value = getComputedStyle(hostEl).getPropertyValue(name).trim() || fallback;
     cssVarCache.set(name, value);
     return value;
+  }
+
+  function labelFontFamily(): string {
+    return cssVar("--font-editor", LABEL_FONT_FALLBACK);
   }
 
   const [initError, setInitError] = createSignal<string | null>(null);
@@ -592,7 +600,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     for (const [filePath, sprite] of labelSprites) {
       const node = nodeByPath.get(filePath);
       if (node) {
-        sprite.position.set(node.x ?? 0, (node.y ?? 0) + nodeVisualRadius(node) + 6, node.z ?? 0);
+        sprite.position.set(node.x ?? 0, (node.y ?? 0) + labelYOffset(node), node.z ?? 0);
       }
     }
   }
@@ -655,7 +663,32 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     labelSprites.clear();
   }
 
-  /** Labels exist only for the hovered/selected/current stars (max three). */
+  function isEmphasizedLabel(node: FGNode): boolean {
+    return node.filePath === selectedNode() || node.filePath === currentFilePath();
+  }
+
+  function labelYOffset(node: FGNode): number {
+    return nodeVisualRadius(node) + (isEmphasizedLabel(node) ? 7 : 4.8);
+  }
+
+  function configureLabel(sprite: SpriteText, node: FGNode, dark: boolean): void {
+    const emphasized = isEmphasizedLabel(node);
+    sprite.text = shortLabel(node.name);
+    sprite.textHeight = emphasized ? 3.4 : 2.7;
+    sprite.color = dark ? "#f7f4ff" : "#1d172b";
+    sprite.fontFace = labelFontFamily();
+    sprite.fontWeight = emphasized ? "700" : "500";
+    sprite.backgroundColor = dark ? "rgba(18,18,20,0.92)" : "rgba(255,255,255,0.96)";
+    sprite.borderColor = labelBorderColor(node);
+    sprite.borderWidth = emphasized ? 0.55 : 0.25;
+    sprite.borderRadius = 2;
+    sprite.padding = emphasized ? [3, 2] : [2, 1.5];
+    sprite.renderOrder = 1000;
+    sprite.material.depthTest = false;
+    sprite.material.depthWrite = false;
+    sprite.position.set(node.x ?? 0, (node.y ?? 0) + labelYOffset(node), node.z ?? 0);
+  }
+
   function updateLabels(): void {
     if (!graphEl) return;
     if (!labelGroup) {
@@ -664,12 +697,18 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     }
 
     const targets = new Set<string>();
-    const hovered = hoveredNode()?.filePath;
-    if (hovered) targets.add(hovered);
-    const selected = selectedNode();
-    if (selected) targets.add(selected);
-    const current = currentFilePath();
-    if (current) targets.add(current);
+    for (const node of starNodes) {
+      const selected = node.filePath === selectedNode();
+      const current = node.filePath === currentFilePath();
+      const hovered = node.filePath === hoveredNode()?.filePath;
+      const hoverOnly = hovered && !selected && !current;
+      const showLabel =
+        !hoverOnly &&
+        (selected ||
+          current ||
+          (!isDenseGraph() && zoomLevel() >= getGraphSettings("3d").labelVisibilityThreshold));
+      if (showLabel) targets.add(node.filePath);
+    }
 
     for (const [filePath, sprite] of labelSprites) {
       if (!targets.has(filePath) || !nodeByPath.has(filePath)) {
@@ -680,23 +719,15 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
 
     const dark = getEffectiveTheme() === "dark";
     for (const filePath of targets) {
-      if (labelSprites.has(filePath)) continue;
       const node = nodeByPath.get(filePath);
       if (!node) continue;
-      const label = new SpriteText(shortLabel(node.name), 3.2, dark ? "#f7f4ff" : "#1d172b");
-      label.fontFace = "Goorm Sans, -apple-system, BlinkMacSystemFont, sans-serif";
-      label.fontWeight = "600";
-      label.backgroundColor = dark ? "rgba(10,12,22,0.88)" : "rgba(255,255,255,0.94)";
-      label.borderColor = labelBorderColor(node);
-      label.borderWidth = 0.45;
-      label.borderRadius = 2;
-      label.padding = [3, 2];
-      label.renderOrder = 1000;
-      label.material.depthTest = false;
-      label.material.depthWrite = false;
-      label.position.set(node.x ?? 0, (node.y ?? 0) + nodeVisualRadius(node) + 6, node.z ?? 0);
-      labelGroup.add(label);
-      labelSprites.set(filePath, label);
+      let label = labelSprites.get(filePath);
+      if (!label) {
+        label = new SpriteText();
+        labelGroup.add(label);
+        labelSprites.set(filePath, label);
+      }
+      configureLabel(label, node, dark);
     }
   }
 
@@ -1017,7 +1048,16 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     if (!graphEl) return;
     const { x, y, z } = graphEl.cameraPosition();
     const dist = Math.max(1, Math.sqrt(x * x + y * y + z * z));
-    setZoomLevel(Math.max(0.1, Math.min(8, 480 / dist)));
+    const nextZoom = Math.max(0.1, Math.min(8, 480 / dist));
+    setZoomLevel(Math.round(nextZoom * 100) / 100);
+  }
+
+  function scheduleZoomFromCamera(): void {
+    if (zoomFrame !== undefined) return;
+    zoomFrame = requestAnimationFrame(() => {
+      zoomFrame = undefined;
+      updateZoomFromCamera();
+    });
   }
 
   function cancelCameraAnimation(): void {
@@ -1200,8 +1240,17 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       instance
         .renderer()
         .setPixelRatio(isDenseGraph() ? 1 : Math.min(window.devicePixelRatio, 1.5));
-      const controls = instance.controls() as { zoomSpeed?: number };
+      const controls = instance.controls() as {
+        zoomSpeed?: number;
+        addEventListener?: (type: "change", listener: () => void) => void;
+        removeEventListener?: (type: "change", listener: () => void) => void;
+      };
       controls.zoomSpeed = GRAPH_3D_SCROLL_ZOOM_SPEED;
+      const handleControlsChange = () => scheduleZoomFromCamera();
+      controls.addEventListener?.("change", handleControlsChange);
+      removeControlsChangeListener = () => {
+        controls.removeEventListener?.("change", handleControlsChange);
+      };
 
       // The ThreeForceGraph group is the scene child exposing graphData();
       // we spin it (plus the dust cloud) for the universe self-rotation.
@@ -1320,6 +1369,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
         // Node sizing settings feed the star buffer and proxy scales.
         proxyCache.clear();
         updateStarVisuals();
+        updateLabels();
         graphEl.refresh();
       },
       { defer: true },
@@ -1340,7 +1390,7 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
 
   createEffect(
     on(
-      () => [hoveredNode(), selectedNode(), currentFilePath()] as const,
+      () => [hoveredNode(), selectedNode(), currentFilePath(), zoomLevel()] as const,
       () => {
         if (!graphEl) return;
         // Stars and labels update via buffers/pools; refresh() only needs to
@@ -1373,6 +1423,18 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
 
   createEffect(
     on(
+      () => [settingsState.editor.fontFamily, currentLocale()] as const,
+      () => {
+        cssVarCache.delete("--font-editor");
+        updateLabels();
+        graphEl?.refresh();
+      },
+      { defer: true },
+    ),
+  );
+
+  createEffect(
+    on(
       () => currentFilePath(),
       (fp) => {
         if (fp) setSelectedNode(fp);
@@ -1390,6 +1452,12 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   onCleanup(() => {
     cancelCameraAnimation();
     stopSceneryLoop();
+    removeControlsChangeListener?.();
+    removeControlsChangeListener = undefined;
+    if (zoomFrame !== undefined) {
+      cancelAnimationFrame(zoomFrame);
+      zoomFrame = undefined;
+    }
     disposeScenery();
     disposeNodeStars();
     clearLabels();

--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
@@ -1,8 +1,19 @@
 // ── Graph Canvas 3D ──
 //
-// Three.js-backed graph renderer for the full graph tab. It intentionally
-// shares GraphStore and GraphCanvasHandle with the 2D canvas so the tab can
-// switch renderers without changing graph indexing or navigation behavior.
+// Three.js-backed "infinite universe" graph renderer for the full graph tab.
+// It intentionally shares GraphStore and GraphCanvasHandle with the 2D canvas
+// so the tab can switch renderers without changing graph indexing or
+// navigation behavior.
+//
+// Rendering architecture: ALL node stars live in a single THREE.Points draw
+// call with a star point-spread-function shader (hot core, tight falloff,
+// diffraction spikes on hubs). Per node the scene only carries an invisible
+// low-poly raycast proxy, so hover/selection changes are O(n) typed-array
+// attribute writes — no object or material churn. Clusters settle
+// volumetrically through 3D space (no galactic plane); the galaxy look comes
+// from the data itself (hub luminosity, cluster cores, depth dimming), not
+// from decorative glow sprites. Theme-aware: additive blending on dark,
+// normal blending with darker pigments on light.
 
 import {
   FitViewIcon,
@@ -24,7 +35,19 @@ import {
 } from "solid-js";
 import ForceGraph3D, { type ConfigOptions, type ForceGraph3DInstance } from "3d-force-graph";
 import SpriteText from "three-spritetext";
-import { Group, Mesh, MeshPhysicalMaterial, SphereGeometry } from "three";
+import {
+  AdditiveBlending,
+  BufferGeometry,
+  Color,
+  Float32BufferAttribute,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  NormalBlending,
+  Points,
+  ShaderMaterial,
+  SphereGeometry,
+} from "three";
 
 import { t, tf } from "~/i18n";
 import { getEffectiveTheme } from "~/stores/theme";
@@ -68,7 +91,6 @@ interface CameraPoint {
   z: number;
 }
 
-const NODE_GEOMETRY = new SphereGeometry(1, 24, 16);
 const GRAPH_3D_NODE_REL_SIZE = 1;
 const Graph3DConstructor = ForceGraph3D as unknown as Graph3DConstructor;
 const DENSE_GRAPH_NODE_COUNT = 500;
@@ -77,6 +99,205 @@ const HUGE_GRAPH_NODE_COUNT = 1_500;
 const DENSE_LINK_RATIO = 2.2;
 const LARGE_LINK_RATIO = 3;
 const HUGE_LINK_RATIO = 4;
+
+// ── Universe rendering ────────────────────────────────────────
+//
+// Two Points layers total: the background starfield and the node-star layer.
+// Twinkling and star shading happen entirely in shaders off a handful of
+// uniforms; per-node hover/selection state is pushed as buffer attributes.
+
+const WHITE = new Color("#ffffff");
+const STARFIELD_COUNT_FULL = 1280;
+const STARFIELD_COUNT_COMPACT = 420;
+const STAR_TINTS_DARK = ["#ffffff", "#ffffff", "#cfe0ff", "#ffeccf", "#e2d6ff"];
+const STAR_TINTS_LIGHT = ["#3c4356", "#3c4356", "#4a4f6e", "#6b5e8a", "#54648a"];
+
+/** Universe self-rotation (around y) in rad/s — one revolution every ~7 min. */
+const GALAXY_ROTATION_SPEED = 0.015;
+/** Keep the view steady for a while after locating a node. */
+const GALAXY_LOCATE_GRACE_MS = 6000;
+const GALAXY_HALO_RADIUS_RATIO = 1.45;
+const GALAXY_INITIAL_CAMERA: CameraPoint = { x: 0, y: -300, z: 440 };
+
+/** Pixel size multiplier from node visual radius to star point size. */
+const STAR_SIZE_BASE = 6.5;
+/** Hubs with at least this many links get diffraction spikes. */
+const STAR_SPIKE_MIN_LINKS = 5;
+
+/**
+ * Invisible raycast proxy shared by every node: hover/click picking needs a
+ * mesh per node, but it never draws a fragment (colorWrite off) and shares
+ * one geometry + one material across the whole graph.
+ */
+const NODE_PROXY_GEOMETRY = new SphereGeometry(1, 6, 4);
+const NODE_PROXY_MATERIAL = new MeshBasicMaterial({
+  transparent: true,
+  opacity: 0,
+  depthWrite: false,
+  colorWrite: false,
+});
+
+const STARFIELD_VERTEX = /* glsl */ `
+  attribute float aSize;
+  attribute float aPhase;
+  attribute vec3 aColor;
+  uniform float uTime;
+  uniform float uPixelRatio;
+  varying float vAlpha;
+  varying vec3 vColor;
+
+  void main() {
+    vColor = aColor;
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    float twinkle = 0.62 + 0.38 * sin(uTime * (0.5 + aPhase * 1.9) + aPhase * 6.2831);
+    vAlpha = twinkle;
+    gl_PointSize = min(aSize * uPixelRatio * (2400.0 / -mvPosition.z), 9.0 * uPixelRatio);
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+const STARFIELD_FRAGMENT = /* glsl */ `
+  uniform float uOpacity;
+  varying float vAlpha;
+  varying vec3 vColor;
+
+  void main() {
+    float dist = length(gl_PointCoord - 0.5);
+    float alpha = smoothstep(0.5, 0.08, dist);
+    gl_FragColor = vec4(vColor, alpha * vAlpha * uOpacity);
+  }
+`;
+
+const NODE_STAR_VERTEX = /* glsl */ `
+  attribute float aSize;
+  attribute float aAlpha;
+  attribute float aSpike;
+  attribute vec3 aColor;
+  uniform float uPixelRatio;
+  varying vec3 vColor;
+  varying float vAlpha;
+  varying float vSpike;
+
+  void main() {
+    vColor = aColor;
+    vSpike = aSpike;
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    // Slight distance dimming sells volumetric depth without a fog pass.
+    vAlpha = aAlpha * clamp(1.35 - (-mvPosition.z) / 3200.0, 0.7, 1.0);
+    gl_PointSize = clamp(aSize * uPixelRatio * (1100.0 / -mvPosition.z), 2.5, 84.0 * uPixelRatio);
+    gl_Position = projectionMatrix * mvPosition;
+  }
+`;
+
+const NODE_STAR_FRAGMENT = /* glsl */ `
+  uniform float uOpacity;
+  uniform float uHot;
+  varying vec3 vColor;
+  varying float vAlpha;
+  varying float vSpike;
+
+  void main() {
+    vec2 uv = gl_PointCoord * 2.0 - 1.0;
+    float d = length(uv);
+    // Star point-spread function: hot core, tight halo, and faint
+    // diffraction spikes on bright stars only.
+    float core = exp(-d * d * 9.0);
+    float halo = 0.45 * exp(-d * d * 2.4);
+    float spike = vSpike * 0.5 * exp(-min(abs(uv.x), abs(uv.y)) * 16.0) * exp(-d * 2.2);
+    float alpha = (core + halo + spike) * vAlpha * uOpacity;
+    if (alpha < 0.012) discard;
+    vec3 color = mix(vColor, vec3(1.0), core * uHot);
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+/** Deterministic PRNG so the star layout survives theme rebuilds unchanged. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a += 1831565813; // 0x6D2B79F5 (mulberry32 increment)
+    let mixed = a;
+    mixed = Math.imul(mixed ^ (mixed >>> 15), mixed | 1);
+    mixed ^= mixed + Math.imul(mixed ^ (mixed >>> 7), mixed | 61);
+    return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createStarfield(theme: "dark" | "light", count: number, pixelRatio: number): Points {
+  const rand = mulberry32(1337);
+  const positions = new Float32Array(count * 3);
+  const sizes = new Float32Array(count);
+  const phases = new Float32Array(count);
+  const colors = new Float32Array(count * 3);
+  const tints = (theme === "dark" ? STAR_TINTS_DARK : STAR_TINTS_LIGHT).map(
+    (tint) => new Color(tint),
+  );
+
+  for (let i = 0; i < count; i++) {
+    // Uniform direction on a sphere, pushed out into a wide shell so stars
+    // always sit behind the graph regardless of camera orbit.
+    const radius = 1500 + rand() * 1700;
+    const theta = rand() * Math.PI * 2;
+    const cosPhi = rand() * 2 - 1;
+    const sinPhi = Math.sqrt(1 - cosPhi * cosPhi);
+    positions[i * 3] = radius * sinPhi * Math.cos(theta);
+    positions[i * 3 + 1] = radius * cosPhi;
+    positions[i * 3 + 2] = radius * sinPhi * Math.sin(theta);
+    sizes[i] = 0.9 + rand() * 2.3 + (rand() < 0.06 ? 2.4 : 0);
+    phases[i] = rand();
+    const tint = tints[Math.floor(rand() * tints.length)] ?? WHITE;
+    colors[i * 3] = tint.r;
+    colors[i * 3 + 1] = tint.g;
+    colors[i * 3 + 2] = tint.b;
+  }
+
+  const geometry = new BufferGeometry();
+  geometry.setAttribute("position", new Float32BufferAttribute(positions, 3));
+  geometry.setAttribute("aSize", new Float32BufferAttribute(sizes, 1));
+  geometry.setAttribute("aPhase", new Float32BufferAttribute(phases, 1));
+  geometry.setAttribute("aColor", new Float32BufferAttribute(colors, 3));
+
+  const material = new ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    blending: theme === "dark" ? AdditiveBlending : NormalBlending,
+    uniforms: {
+      uTime: { value: 0 },
+      uPixelRatio: { value: pixelRatio },
+      uOpacity: { value: theme === "dark" ? 0.7 : 0.45 },
+    },
+    vertexShader: STARFIELD_VERTEX,
+    fragmentShader: STARFIELD_FRAGMENT,
+  });
+
+  const points = new Points(geometry, material);
+  points.renderOrder = -20;
+  points.frustumCulled = false;
+  return points;
+}
+
+/**
+ * Cluster anchor points spread uniformly through a 3D ball: Fibonacci-sphere
+ * directions combined with a cube-root radius ramp. The cluster force pulls
+ * members toward these, so the settled layout reads as star clusters floating
+ * in an open universe — no galactic plane, no spiral arms.
+ */
+function universeClusterCenters(count: number, radius: number): Map<number, CameraPoint> {
+  const centers = new Map<number, CameraPoint>();
+  const golden = Math.PI * (3 - Math.sqrt(5));
+  for (let i = 0; i < count; i++) {
+    const cosPhi = count > 1 ? 1 - (2 * (i + 0.5)) / count : 0;
+    const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
+    const theta = i * golden;
+    const r = radius * (0.35 + 0.65 * Math.cbrt((i + 0.5) / count));
+    centers.set(i, {
+      x: Math.cos(theta) * sinPhi * r,
+      y: Math.sin(theta) * sinPhi * r,
+      z: cosPhi * r,
+    });
+  }
+  return centers;
+}
 
 interface NodeOpacityOptions {
   selected: boolean;
@@ -100,16 +321,10 @@ function lerpPoint(from: CameraPoint, to: CameraPoint, progress: number): Camera
 function nodeOpacity(options: NodeOpacityOptions): number {
   const fadeOpacity = getGraphSettings("3d").hoverFadeOpacity;
   if (options.selected) return 1;
-  if (options.highlighted) return 0.98;
-  if (options.softHighlighted) return 0.88;
+  if (options.highlighted) return 1;
+  if (options.softHighlighted) return 0.92;
   if (options.hasFocus) return fadeOpacity;
-  return 0.72;
-}
-
-function nodeScale(radius: number, highlighted: boolean, softHighlighted: boolean): number {
-  if (highlighted) return radius;
-  if (softHighlighted) return radius;
-  return radius;
+  return 0.88;
 }
 
 function isObjectNode(value: string | FGNode): value is FGNode {
@@ -159,6 +374,12 @@ function budgetNumber(
   return values[budget];
 }
 
+function disposeLabel(sprite: SpriteText): void {
+  sprite.parent?.remove(sprite);
+  sprite.material.map?.dispose();
+  sprite.material.dispose();
+}
+
 export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   let hostEl: HTMLDivElement | undefined;
   let graphEl: Graph3D | undefined;
@@ -170,6 +391,23 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   let lastHugeHoverAt = 0;
 
   const cssVarCache = new Map<string, string>();
+
+  // Raycast proxies keyed by node id — refresh() re-runs nodeThreeObject for
+  // every node, so returning the cached instance makes a refresh allocation-
+  // free for nodes. Cleared when data or sizing settings change.
+  const proxyCache = new Map<string, Mesh>();
+
+  // CSS color string → THREE.Color, shared by all star attribute updates.
+  const parsedColorCache = new Map<string, Color>();
+
+  function parsedColor(css: string): Color {
+    let color = parsedColorCache.get(css);
+    if (!color) {
+      color = new Color(css);
+      parsedColorCache.set(css, color);
+    }
+    return color;
+  }
 
   /** Resolve theme tokens from the graph host (same pattern as 2D canvas). */
   function cssVar(name: string, fallback = ""): string {
@@ -236,6 +474,269 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
   const isLargeGraph = () => renderBudget() === "large" || renderBudget() === "huge";
   const isHugeGraph = () => renderBudget() === "huge";
 
+  // ── Universe scenery state ──
+  let starfield: Points | undefined;
+  let sceneryFrame: number | undefined;
+  let sceneryStartedAt = 0;
+  let lastSceneryFrameAt = 0;
+  /** The ThreeForceGraph group inside the scene — rotated for universe spin. */
+  let graphObj: Group | undefined;
+  let galaxyAngle = 0;
+  let lastLocateAt = 0;
+
+  // ── Node star layer (one draw call for every node) ──
+  let nodeStars: Points | undefined;
+  let starNodes: FGNode[] = [];
+  const nodeByPath = new Map<string, FGNode>();
+  let labelGroup: Group | undefined;
+  const labelSprites = new Map<string, SpriteText>();
+
+  function galaxyRadius(): number {
+    const { width, height } = dimensions();
+    return Math.min(width, height) * getGraphSettings("3d").clusterRadiusFactor * 0.7;
+  }
+
+  function disposeScenery(): void {
+    if (starfield && graphEl) {
+      graphEl.scene().remove(starfield);
+      starfield.geometry.dispose();
+      (starfield.material as ShaderMaterial).dispose();
+    }
+    starfield = undefined;
+  }
+
+  /**
+   * (Re)build the background starfield for the active theme. Deliberately no
+   * soft glow sprites (galactic core, nebulas, dust blobs): large additive
+   * shapes stack into a washed-out haze, so only point-sized scenery exists.
+   */
+  function buildScenery(): void {
+    if (!graphEl) return;
+    disposeScenery();
+    starfield = createStarfield(
+      getEffectiveTheme(),
+      isCompact() ? STARFIELD_COUNT_COMPACT : STARFIELD_COUNT_FULL,
+      graphEl.renderer().getPixelRatio(),
+    );
+    graphEl.scene().add(starfield);
+  }
+
+  function disposeNodeStars(): void {
+    if (nodeStars) {
+      nodeStars.parent?.remove(nodeStars);
+      nodeStars.geometry.dispose();
+      (nodeStars.material as ShaderMaterial).dispose();
+    }
+    nodeStars = undefined;
+    starNodes = [];
+    nodeByPath.clear();
+  }
+
+  /** Rebuild the node-star Points layer from the current graph data. */
+  function buildNodeStars(): void {
+    if (!graphEl) return;
+    disposeNodeStars();
+    const { nodes } = graphEl.graphData();
+    if (nodes.length === 0) return;
+    starNodes = nodes;
+    for (const node of nodes) nodeByPath.set(node.filePath, node);
+
+    const n = nodes.length;
+    const geometry = new BufferGeometry();
+    geometry.setAttribute("position", new Float32BufferAttribute(new Float32Array(n * 3), 3));
+    geometry.setAttribute("aColor", new Float32BufferAttribute(new Float32Array(n * 3), 3));
+    geometry.setAttribute("aSize", new Float32BufferAttribute(new Float32Array(n), 1));
+    geometry.setAttribute("aAlpha", new Float32BufferAttribute(new Float32Array(n), 1));
+    geometry.setAttribute("aSpike", new Float32BufferAttribute(new Float32Array(n), 1));
+
+    const dark = getEffectiveTheme() === "dark";
+    const material = new ShaderMaterial({
+      transparent: true,
+      depthWrite: false,
+      blending: dark ? AdditiveBlending : NormalBlending,
+      uniforms: {
+        uPixelRatio: { value: graphEl.renderer().getPixelRatio() },
+        uOpacity: { value: 1 },
+        uHot: { value: dark ? 0.78 : 0.12 },
+      },
+      vertexShader: NODE_STAR_VERTEX,
+      fragmentShader: NODE_STAR_FRAGMENT,
+    });
+
+    nodeStars = new Points(geometry, material);
+    nodeStars.frustumCulled = false;
+    nodeStars.renderOrder = 10;
+    // Child of the graph group → inherits the universe spin automatically.
+    (graphObj ?? graphEl.scene()).add(nodeStars);
+    syncStarPositions();
+    updateStarVisuals();
+  }
+
+  /** Copy simulation positions into the star buffer (runs per engine tick). */
+  function syncStarPositions(): void {
+    if (!nodeStars || starNodes.length === 0) return;
+    const attr = nodeStars.geometry.getAttribute("position") as Float32BufferAttribute;
+    const arr = attr.array as Float32Array;
+    for (let i = 0; i < starNodes.length; i++) {
+      const node = starNodes[i];
+      if (!node) continue;
+      arr[i * 3] = node.x ?? 0;
+      arr[i * 3 + 1] = node.y ?? 0;
+      arr[i * 3 + 2] = node.z ?? 0;
+    }
+    attr.needsUpdate = true;
+    for (const [filePath, sprite] of labelSprites) {
+      const node = nodeByPath.get(filePath);
+      if (node) {
+        sprite.position.set(node.x ?? 0, (node.y ?? 0) + nodeVisualRadius(node) + 6, node.z ?? 0);
+      }
+    }
+  }
+
+  /**
+   * Push hover/selection/theme state into star attributes. O(n) typed-array
+   * writes — replaces the old per-node object/material rebuild entirely.
+   */
+  function updateStarVisuals(): void {
+    if (!nodeStars || starNodes.length === 0) return;
+    const geometry = nodeStars.geometry;
+    const colorAttr = geometry.getAttribute("aColor") as Float32BufferAttribute;
+    const sizeAttr = geometry.getAttribute("aSize") as Float32BufferAttribute;
+    const alphaAttr = geometry.getAttribute("aAlpha") as Float32BufferAttribute;
+    const spikeAttr = geometry.getAttribute("aSpike") as Float32BufferAttribute;
+    const colors = colorAttr.array as Float32Array;
+    const sizes = sizeAttr.array as Float32Array;
+    const alphas = alphaAttr.array as Float32Array;
+    const spikes = spikeAttr.array as Float32Array;
+
+    const selected = selectedNode();
+    const connected = connectedToFocus();
+    const hasFocus = Boolean(focusedFilePath());
+
+    for (let i = 0; i < starNodes.length; i++) {
+      const node = starNodes[i];
+      if (!node) continue;
+      const highlighted = isHighlightedNode(node);
+      const soft = highlighted || connected.has(node.filePath);
+      const color = parsedColor(nodeColor(node));
+      colors[i * 3] = color.r;
+      colors[i * 3 + 1] = color.g;
+      colors[i * 3 + 2] = color.b;
+      let scale = 1;
+      if (highlighted) scale = 1.7;
+      else if (soft) scale = 1.25;
+      sizes[i] = nodeVisualRadius(node) * STAR_SIZE_BASE * scale;
+      // Hubs burn brighter — luminosity tracks connectivity like a real
+      // cluster core, so the structure itself carries the galaxy look.
+      const luminosity = 1 + Math.min(node.linkCount, 8) * 0.035;
+      alphas[i] = Math.min(
+        1,
+        nodeOpacity({
+          selected: node.filePath === selected,
+          highlighted,
+          softHighlighted: soft,
+          hasFocus,
+        }) * luminosity,
+      );
+      spikes[i] = highlighted || node.linkCount >= STAR_SPIKE_MIN_LINKS ? 1 : 0;
+    }
+    colorAttr.needsUpdate = true;
+    sizeAttr.needsUpdate = true;
+    alphaAttr.needsUpdate = true;
+    spikeAttr.needsUpdate = true;
+  }
+
+  function clearLabels(): void {
+    for (const sprite of labelSprites.values()) disposeLabel(sprite);
+    labelSprites.clear();
+  }
+
+  /** Labels exist only for the hovered/selected/current stars (max three). */
+  function updateLabels(): void {
+    if (!graphEl) return;
+    if (!labelGroup) {
+      labelGroup = new Group();
+      (graphObj ?? graphEl.scene()).add(labelGroup);
+    }
+
+    const targets = new Set<string>();
+    const hovered = hoveredNode()?.filePath;
+    if (hovered) targets.add(hovered);
+    const selected = selectedNode();
+    if (selected) targets.add(selected);
+    const current = currentFilePath();
+    if (current) targets.add(current);
+
+    for (const [filePath, sprite] of labelSprites) {
+      if (!targets.has(filePath) || !nodeByPath.has(filePath)) {
+        disposeLabel(sprite);
+        labelSprites.delete(filePath);
+      }
+    }
+
+    const dark = getEffectiveTheme() === "dark";
+    for (const filePath of targets) {
+      if (labelSprites.has(filePath)) continue;
+      const node = nodeByPath.get(filePath);
+      if (!node) continue;
+      const label = new SpriteText(shortLabel(node.name), 3.2, dark ? "#f7f4ff" : "#1d172b");
+      label.fontFace = "Goorm Sans, -apple-system, BlinkMacSystemFont, sans-serif";
+      label.fontWeight = "600";
+      label.backgroundColor = dark ? "rgba(10,12,22,0.88)" : "rgba(255,255,255,0.94)";
+      label.borderColor = labelBorderColor(node);
+      label.borderWidth = 0.45;
+      label.borderRadius = 2;
+      label.padding = [3, 2];
+      label.renderOrder = 1000;
+      label.material.depthTest = false;
+      label.material.depthWrite = false;
+      label.position.set(node.x ?? 0, (node.y ?? 0) + nodeVisualRadius(node) + 6, node.z ?? 0);
+      labelGroup.add(label);
+      labelSprites.set(filePath, label);
+    }
+  }
+
+  /** Galaxy spin pauses while the user is inspecting something specific. */
+  function galaxyRotationActive(now: number): boolean {
+    return (
+      !isCameraAnimating &&
+      !hoveredNode() &&
+      now - lastLocateAt > GALAXY_LOCATE_GRACE_MS &&
+      status() === "ready"
+    );
+  }
+
+  /** Drives starfield twinkle + the slow self-rotation of the universe. */
+  function startSceneryLoop(): void {
+    if (sceneryFrame !== undefined) return;
+    sceneryStartedAt = performance.now();
+    lastSceneryFrameAt = sceneryStartedAt;
+    const tick = (now: number) => {
+      sceneryFrame = requestAnimationFrame(tick);
+      const dt = Math.min(100, now - lastSceneryFrameAt);
+      lastSceneryFrameAt = now;
+
+      if (starfield) {
+        const uTime = (starfield.material as ShaderMaterial).uniforms.uTime;
+        if (uTime) uTime.value = (now - sceneryStartedAt) / 1000;
+        starfield.rotation.y += 0.00012;
+      }
+
+      if (galaxyRotationActive(now) && graphObj) {
+        galaxyAngle += (dt / 1000) * GALAXY_ROTATION_SPEED;
+        graphObj.rotation.y = galaxyAngle;
+      }
+    };
+    sceneryFrame = requestAnimationFrame(tick);
+  }
+
+  function stopSceneryLoop(): void {
+    if (sceneryFrame !== undefined) {
+      cancelAnimationFrame(sceneryFrame);
+      sceneryFrame = undefined;
+    }
+  }
+
   function nodeColor(node: FGNode): string {
     const theme = getEffectiveTheme();
     if (node.filePath === selectedNode()) {
@@ -296,15 +797,6 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     );
   }
 
-  function isSoftHighlightedNode(node: FGNode): boolean {
-    return isHighlightedNode(node) || connectedToFocus().has(node.filePath);
-  }
-
-  function shouldUseCustomNodeObject(node: FGNode): boolean {
-    if (isHugeGraph()) return isHighlightedNode(node);
-    return !isDenseGraph() || isSoftHighlightedNode(node);
-  }
-
   function linkVisible(link: FGLink): boolean {
     if (!isHugeGraph() || isFocusedLink(link)) return true;
     const sourceId = isObjectNode(link.source) ? link.source.filePath : link.source;
@@ -345,32 +837,25 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     return clusterColor(node.clusterIndex, 0.3);
   }
 
+  // Width 0 makes three-forcegraph render the link as a plain 2-vertex Line
+  // instead of a cylinder mesh — orders of magnitude cheaper. Only the few
+  // focused/highlighted links get real tube geometry.
   function linkWidth(link: FGLink): number {
     const scale = getGraphSettings("3d").linkWidthScale;
     if (isFocusedLink(link)) return 2.15 * scale;
     if (isHighlightedLink(link)) return 1.1 * scale;
-    if (isHugeGraph()) return 0.025 * scale;
-    if (isLargeGraph()) return 0.05 * scale;
-    if (isDenseGraph()) return 0.12 * scale;
-    if (focusedFilePath()) return 0.08 * scale;
-    return 0.32 * scale;
+    return 0;
   }
 
   function linkOpacityForSettings(): number {
     return Math.min(1, 0.32 * getGraphSettings("3d").linkOpacity);
   }
 
+  // Straight links everywhere except the focused ones: curvature forces
+  // multi-segment geometry per link, so the default stays a 2-vertex line.
   function linkCurvature(link: FGLink): number {
     if (isHugeGraph()) return 0;
-    const curvature = getGraphSettings("3d").linkCurvature;
-    return isFocusedLink(link) ? curvature * 1.35 : curvature;
-  }
-
-  function nodeResolutionForBudget(): number {
-    if (isHugeGraph()) return 8;
-    if (isLargeGraph()) return 10;
-    if (isDenseGraph()) return 10;
-    return 16;
+    return isFocusedLink(link) ? getGraphSettings("3d").linkCurvature * 1.35 : 0;
   }
 
   function alphaDecayForBudget(): number {
@@ -403,67 +888,19 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     return Math.min(getGraphSettings("3d").cooldownTicks, 120);
   }
 
-  function nodeThreeObject(node: FGNode): Group | undefined {
-    if (!shouldUseCustomNodeObject(node)) return undefined;
-
-    const radius = nodeVisualRadius(node);
-    const color = nodeColor(node);
-    const group = new Group();
-    const selected = node.filePath === selectedNode();
-    const current = node.filePath === currentFilePath();
-    const hovered = node.filePath === hoveredNode()?.filePath;
-    const hoverOnly = hovered && !selected && !current;
-    const highlighted = isHighlightedNode(node);
-    const softHighlighted = isSoftHighlightedNode(node);
-    const hasFocus = Boolean(focusedFilePath());
-
-    const core = new Mesh(
-      NODE_GEOMETRY,
-      new MeshPhysicalMaterial({
-        color,
-        transparent: !selected,
-        opacity: nodeOpacity({ selected, highlighted, softHighlighted, hasFocus }),
-        roughness: selected ? 0.38 : 0.46,
-        metalness: selected ? 0.02 : 0,
-        clearcoat: selected ? 0.38 : 0.22,
-        clearcoatRoughness: selected ? 0.42 : 0.5,
-        transmission: 0,
-        thickness: 0,
-        depthWrite: selected,
-      }),
-    );
-    const scale = nodeScale(radius, highlighted, softHighlighted);
-    core.scale.setScalar(scale);
-    group.add(core);
-
-    const showLabel =
-      !hoverOnly &&
-      (selected ||
-        current ||
-        (!isDenseGraph() && zoomLevel() >= getGraphSettings("3d").labelVisibilityThreshold));
-    if (showLabel) {
-      const labelColor = getEffectiveTheme() === "dark" ? "#f7f4ff" : "#1d172b";
-      const label = new SpriteText(
-        shortLabel(node.name),
-        focusedFilePath() === node.filePath ? 3.4 : 2.7,
-        labelColor,
-      );
-      label.fontFace = "Goorm Sans, -apple-system, BlinkMacSystemFont, sans-serif";
-      label.fontWeight = focusedFilePath() === node.filePath || current ? "700" : "500";
-      label.backgroundColor =
-        getEffectiveTheme() === "dark" ? "rgba(18,18,20,0.92)" : "rgba(255,255,255,0.96)";
-      label.borderColor = labelBorderColor(node);
-      label.borderWidth = focusedFilePath() === node.filePath ? 0.55 : 0.25;
-      label.borderRadius = 2;
-      label.padding = focusedFilePath() === node.filePath ? [3, 2] : [2, 1.5];
-      label.position.y = radius + (focusedFilePath() === node.filePath ? 7 : 4.8);
-      label.renderOrder = 1000;
-      label.material.depthTest = false;
-      label.material.depthWrite = false;
-      group.add(label);
+  /**
+   * Every node's scene object is just an invisible raycast proxy — the
+   * visible star lives in the shared Points layer. Cached per node id so a
+   * refresh() allocates nothing.
+   */
+  function nodeThreeObject(node: FGNode): Mesh {
+    let proxy = proxyCache.get(node.id);
+    if (!proxy) {
+      proxy = new Mesh(NODE_PROXY_GEOMETRY, NODE_PROXY_MATERIAL);
+      proxy.scale.setScalar(Math.max(2.4, nodeVisualRadius(node) * 1.5));
+      proxyCache.set(node.id, proxy);
     }
-
-    return group;
+    return proxy;
   }
 
   function configureForces(options: { reheat?: boolean } = {}): void {
@@ -471,8 +908,6 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     const cfg = getGraphSettings("3d");
     const budget = renderBudget();
     const dense = budget !== "normal";
-    const large = budget === "large";
-    const huge = budget === "huge";
     const chargeMultiplier = budgetNumber(budget, {
       normal: 1,
       dense: 0.82,
@@ -520,32 +955,49 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       ?.strength?.(() => Math.max(0, cfg.linkStrength) * (dense ? 0.42 : 0.68));
     graphEl.d3Force("link")?.iterations?.(dense ? 1 : 2);
 
+    // Universe layout force: clusters settle around anchors spread through a
+    // 3D ball, orphans drift out to a sparse spherical shell around it. It
+    // stays on for large/huge graphs (O(n) per tick, far cheaper than the
+    // n·log n charge force) — only its strength drops.
     const clusters = graphState()?.clusters ?? [];
-    if (clusters.length > 1 && !large && !huge) {
-      const { width, height } = dimensions();
-      const clusterRadius = Math.min(width, height) * cfg.clusterRadiusFactor * 0.7;
-      const angleStep = (2 * Math.PI) / clusters.length;
-      const centers = new Map<number, { x: number; y: number; z: number }>();
-
-      clusters.forEach((_: string, i: number) => {
-        const angle = i * angleStep - Math.PI / 2;
-        centers.set(i, {
-          x: Math.cos(angle) * clusterRadius,
-          y: Math.sin(angle) * clusterRadius,
-          z: Math.sin(angle * 1.7) * clusterRadius * 0.34,
-        });
+    if (clusters.length > 1) {
+      const radius = galaxyRadius();
+      const centers = universeClusterCenters(clusters.length, radius);
+      const haloRadius = radius * GALAXY_HALO_RADIUS_RATIO;
+      const budgetScale = budgetNumber(budget, {
+        normal: 0.72,
+        dense: 0.45,
+        large: 0.4,
+        huge: 0.3,
       });
 
       graphEl.d3Force("cluster", (alpha: number) => {
         const data = graphEl?.graphData();
         if (!data) return;
+        const strength = cfg.clusterStrength * alpha * budgetScale;
         for (const node of data.nodes) {
+          const x = node.x ?? 0;
+          const y = node.y ?? 0;
+          const z = node.z ?? 0;
+
+          if (node.isOrphan) {
+            // Lone stars: pushed radially out to a thin spherical shell.
+            const r = Math.hypot(x, y, z) || 1;
+            const haloStrength = strength * 0.5;
+            node.vx = (node.vx ?? 0) + ((x / r) * haloRadius - x) * haloStrength;
+            node.vy = (node.vy ?? 0) + ((y / r) * haloRadius - y) * haloStrength;
+            node.vz = (node.vz ?? 0) + ((z / r) * haloRadius - z) * haloStrength;
+            continue;
+          }
+
           const center = centers.get(node.clusterIndex);
           if (!center) continue;
-          const strength = cfg.clusterStrength * alpha * (dense ? 0.34 : 0.72);
-          node.vx = (node.vx ?? 0) + (center.x - (node.x ?? 0)) * strength;
-          node.vy = (node.vy ?? 0) + (center.y - (node.y ?? 0)) * strength;
-          node.vz = (node.vz ?? 0) + (center.z - (node.z ?? 0)) * strength;
+          // Hubs sink toward the cluster center: dense bright cores with
+          // sparse outskirts, like a real star cluster's density profile.
+          const pull = strength * (1 + Math.min(node.linkCount, 10) * 0.06);
+          node.vx = (node.vx ?? 0) + (center.x - x) * pull;
+          node.vy = (node.vy ?? 0) + (center.y - y) * pull;
+          node.vz = (node.vz ?? 0) + (center.z - z) * pull;
         }
       });
     } else {
@@ -639,7 +1091,9 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       node.fy = undefined;
       node.fz = undefined;
     }
-    graphEl.cameraPosition({ x: 0, y: 0, z: 520 }, { x: 0, y: 0, z: 0 }, 500);
+    galaxyAngle = 0;
+    if (graphObj) graphObj.rotation.y = 0;
+    graphEl.cameraPosition(GALAXY_INITIAL_CAMERA, { x: 0, y: 0, z: 0 }, 500);
     graphEl.d3ReheatSimulation();
     setZoomLevel(1);
   }
@@ -649,21 +1103,29 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     const node = graphEl.graphData().nodes.find((n) => n.filePath === filePath);
     if (node?.x === undefined || node.y === undefined || node.z === undefined) return;
 
+    // Node coordinates are universe-local; the graph group spins around y, so
+    // rotate into world space before aiming the camera.
+    const ca = Math.cos(galaxyAngle);
+    const sa = Math.sin(galaxyAngle);
+    const wx = node.x * ca + node.z * sa;
+    const wy = node.y;
+    const wz = -node.x * sa + node.z * ca;
+
     const currentCamera = graphEl.cameraPosition();
-    const dx = currentCamera.x - node.x;
-    const dy = currentCamera.y - node.y;
-    const dz = currentCamera.z - node.z;
+    const dx = currentCamera.x - wx;
+    const dy = currentCamera.y - wy;
+    const dz = currentCamera.z - wz;
     const len = Math.hypot(dx, dy, dz) || 1;
     const dist = Math.max(220, nodeRadius(node) * 18 + 150);
     const camera = {
-      x: node.x + (dx / len) * dist,
-      y: node.y + (dy / len) * dist,
-      z: node.z + (dz / len) * dist,
+      x: wx + (dx / len) * dist,
+      y: wy + (dy / len) * dist,
+      z: wz + (dz / len) * dist,
     };
     setHoveredNode(null);
     setSelectedNode(filePath);
-    graphEl.refresh();
-    smoothCameraTo(camera, { x: node.x, y: node.y, z: node.z });
+    lastLocateAt = performance.now();
+    smoothCameraTo(camera, { x: wx, y: wy, z: wz });
     setZoomLevel(Math.max(0.1, Math.min(8, 480 / dist)));
   }
 
@@ -683,10 +1145,8 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
         .graphData({ nodes: [], links: [] })
         .nodeId("id")
         .nodeVal((node) => Math.max(2, nodeRadius(node)))
-        .nodeColor((node) => nodeColor(node))
-        .nodeThreeObject((node) => nodeThreeObject(node) as Group)
+        .nodeThreeObject((node) => nodeThreeObject(node))
         .nodeRelSize(GRAPH_3D_NODE_REL_SIZE)
-        .nodeResolution(nodeResolutionForBudget())
         .linkColor((link) => linkColor(link))
         .linkWidth((link) => linkWidth(link))
         .linkVisibility((link) => linkVisible(link))
@@ -728,7 +1188,9 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
         .showNavInfo(false)
         .backgroundColor("rgba(0,0,0,0)")
         .enableNodeDrag(false)
-        .enableNavigationControls(true);
+        .enableNavigationControls(true)
+        .onEngineTick(() => syncStarPositions())
+        .onEngineStop(() => syncStarPositions());
 
       graphEl = instance;
       instance
@@ -737,10 +1199,23 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       const controls = instance.controls() as { zoomSpeed?: number };
       controls.zoomSpeed = GRAPH_3D_SCROLL_ZOOM_SPEED;
 
+      // The ThreeForceGraph group is the scene child exposing graphData();
+      // we spin it (plus the dust cloud) for the universe self-rotation.
+      graphObj = instance
+        .scene()
+        .children.find(
+          (child): child is Group =>
+            child instanceof Group &&
+            typeof (child as unknown as { graphData?: unknown }).graphData === "function",
+        );
+
       const rect = hostEl.getBoundingClientRect();
       setDimensions({ width: rect.width, height: rect.height });
       instance.width(rect.width).height(rect.height);
-      instance.cameraPosition({ x: 0.001, y: 0, z: 520 }, { x: 0, y: 0, z: 0 }, 0);
+      // Slightly inclined start view so cluster depth reads immediately.
+      instance.cameraPosition(GALAXY_INITIAL_CAMERA, { x: 0, y: 0, z: 0 }, 0);
+      buildScenery();
+      startSceneryLoop();
 
       resizeObs = new ResizeObserver((entries) => {
         for (const entry of entries) {
@@ -775,14 +1250,23 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
 
         const nodes: FGNode[] = s.nodes.map((n) => ({ ...n }));
         const links: FGLink[] = s.links.map((l) => ({ ...l }));
+        proxyCache.clear();
+        clearLabels();
         graphEl.graphData({ nodes, links });
-        graphEl.nodeResolution(nodeResolutionForBudget());
         graphEl.linkVisibility((link) => linkVisible(link));
         graphEl
           .renderer()
           .setPixelRatio(isDenseGraph() ? 1 : Math.min(window.devicePixelRatio, 1.5));
+        if (starfield) {
+          const uPixelRatio = (starfield.material as ShaderMaterial).uniforms.uPixelRatio;
+          if (uPixelRatio) uPixelRatio.value = graphEl.renderer().getPixelRatio();
+        }
 
-        requestAnimationFrame(() => configureForces());
+        requestAnimationFrame(() => {
+          configureForces();
+          buildNodeStars();
+          updateLabels();
+        });
       },
     ),
   );
@@ -829,6 +1313,9 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
             return settings.showArrows && isFocusedLink(link) ? settings.arrowLength * 1.25 : 0;
           });
         configureForces({ reheat: true });
+        // Node sizing settings feed the star buffer and proxy scales.
+        proxyCache.clear();
+        updateStarVisuals();
         graphEl.refresh();
       },
       { defer: true },
@@ -852,6 +1339,10 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       () => [hoveredNode(), selectedNode(), currentFilePath()] as const,
       () => {
         if (!graphEl) return;
+        // Stars and labels update via buffers/pools; refresh() only needs to
+        // re-evaluate link materials (highlight colors/widths).
+        updateStarVisuals();
+        updateLabels();
         graphEl.refresh();
       },
       { defer: true },
@@ -863,6 +1354,13 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       () => getEffectiveTheme(),
       () => {
         cssVarCache.clear();
+        parsedColorCache.clear();
+        // Blending modes differ per theme, so both Points layers must be
+        // rebuilt — not just retinted.
+        buildScenery();
+        buildNodeStars();
+        clearLabels();
+        updateLabels();
         graphEl?.refresh();
       },
       { defer: true },
@@ -874,7 +1372,6 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
       () => currentFilePath(),
       (fp) => {
         if (fp) setSelectedNode(fp);
-        graphEl?.refresh();
       },
       { defer: true },
     ),
@@ -888,6 +1385,13 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
 
   onCleanup(() => {
     cancelCameraAnimation();
+    stopSceneryLoop();
+    disposeScenery();
+    disposeNodeStars();
+    clearLabels();
+    labelGroup = undefined;
+    proxyCache.clear();
+    parsedColorCache.clear();
     if (hoverFrame !== undefined) {
       cancelAnimationFrame(hoverFrame);
       hoverFrame = undefined;
@@ -909,9 +1413,18 @@ export default function GraphCanvas3D(props: GraphCanvas3DProps) {
     cssVarCache.clear();
   });
 
+  // Near-uniform deep space: a strong radial hotspot reads as yet another
+  // glow blob, so the dark gradient stays almost flat.
+  const backdropGradient = createMemo(() =>
+    getEffectiveTheme() === "dark"
+      ? "radial-gradient(120% 90% at 50% 30%, #0b0e1d 0%, #070912 50%, #030408 100%)"
+      : "radial-gradient(120% 90% at 50% 30%, #ffffff 0%, #f3f4fb 50%, #e7eaf5 100%)",
+  );
+
   return (
     <div
       class={`relative min-h-0 min-w-0 flex-1 overflow-hidden bg-bg-primary ${props.class ?? ""}`}
+      style={{ "background-image": backdropGradient() }}
     >
       <div ref={hostEl} class="absolute inset-0" />
 

--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_3d.tsx
@@ -120,7 +120,7 @@ const GALAXY_HALO_RADIUS_RATIO = 1.45;
 const GALAXY_INITIAL_CAMERA: CameraPoint = { x: 0, y: -300, z: 440 };
 
 /** Pixel size multiplier from node visual radius to star point size. */
-const STAR_SIZE_BASE = 6.5;
+const STAR_SIZE_BASE = 7.5;
 /** Hubs with at least this many links get diffraction spikes. */
 const STAR_SPIKE_MIN_LINKS = 5;
 
@@ -184,7 +184,7 @@ const NODE_STAR_VERTEX = /* glsl */ `
     vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
     // Slight distance dimming sells volumetric depth without a fog pass.
     vAlpha = aAlpha * clamp(1.35 - (-mvPosition.z) / 3200.0, 0.7, 1.0);
-    gl_PointSize = clamp(aSize * uPixelRatio * (1100.0 / -mvPosition.z), 2.5, 84.0 * uPixelRatio);
+    gl_PointSize = clamp(aSize * uPixelRatio * (1100.0 / -mvPosition.z), 2.5, 96.0 * uPixelRatio);
     gl_Position = projectionMatrix * mvPosition;
   }
 `;
@@ -199,13 +199,17 @@ const NODE_STAR_FRAGMENT = /* glsl */ `
   void main() {
     vec2 uv = gl_PointCoord * 2.0 - 1.0;
     float d = length(uv);
-    // Star point-spread function: hot core, tight halo, and faint
-    // diffraction spikes on bright stars only.
-    float core = exp(-d * d * 9.0);
-    float halo = 0.45 * exp(-d * d * 2.4);
-    float spike = vSpike * 0.5 * exp(-min(abs(uv.x), abs(uv.y)) * 16.0) * exp(-d * 2.2);
+    // Star point-spread function: hot core, soft halo, and faint
+    // diffraction spikes on bright stars only. Every term is windowed to
+    // zero before the sprite quad edge so the square frame never shows
+    // through, even on large hub stars.
+    float window = 1.0 - smoothstep(0.5, 0.92, d);
+    float core = exp(-d * d * 10.0);
+    float halo = 0.55 * exp(-d * d * 3.0) * window;
+    float arm = exp(-min(abs(uv.x), abs(uv.y)) * 14.0);
+    float spike = vSpike * 0.55 * arm * exp(-d * 2.6) * window;
     float alpha = (core + halo + spike) * vAlpha * uOpacity;
-    if (alpha < 0.012) discard;
+    if (alpha < 0.01) discard;
     vec3 color = mix(vColor, vec3(1.0), core * uHot);
     gl_FragColor = vec4(color, alpha);
   }

--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_controls_layout.test.ts
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_controls_layout.test.ts
@@ -52,4 +52,17 @@ describe("graph canvas controls layout", () => {
     expect(threeSource).not.toContain("bottom-14 left-3");
     expect(threeSource).not.toContain("connectedToHovered");
   });
+
+  it("uses the configured editor font for graph labels", () => {
+    const pixiSource = source("graph_canvas_pixi.tsx");
+    const threeSource = source("graph_canvas_3d.tsx");
+
+    expect(pixiSource).toContain('cssVar("--font-editor"');
+    expect(pixiSource).toContain("settingsState.editor.fontFamily");
+    expect(pixiSource).not.toContain('fontFamily: "Goorm Sans');
+
+    expect(threeSource).toContain('cssVar("--font-editor"');
+    expect(threeSource).toContain("settingsState.editor.fontFamily");
+    expect(threeSource).not.toContain('sprite.fontFace = "Goorm Sans');
+  });
 });

--- a/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_pixi.tsx
+++ b/apps/desktop/src/plugins/builtin/graph_view/graph_canvas_pixi.tsx
@@ -27,7 +27,8 @@ import {
 } from "solid-js";
 import { Application, Container, Graphics, Text } from "pixi.js";
 
-import { t, tf } from "~/i18n";
+import { currentLocale, t, tf } from "~/i18n";
+import { settingsState } from "~/stores/settings";
 import { getEffectiveTheme } from "~/stores/theme";
 
 import { graphAnimationReplayRevision } from "./graph_animation";
@@ -119,6 +120,7 @@ const HUGE_GRAPH_NODE_COUNT = 1_500;
 const DENSE_LINK_RATIO = 2.2;
 const LARGE_LINK_RATIO = 3;
 const HUGE_LINK_RATIO = 4;
+const LABEL_FONT_FALLBACK = '"Goorm Sans", -apple-system, BlinkMacSystemFont, sans-serif';
 const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
 const UINT32_MAX = 4_294_967_295;
 
@@ -416,6 +418,10 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
   function cssVar(name: string, fallback = ""): string {
     if (!hostEl) return fallback;
     return getComputedStyle(hostEl).getPropertyValue(name).trim() || fallback;
+  }
+
+  function labelFontFamily(): string {
+    return cssVar("--font-editor", LABEL_FONT_FALLBACK);
   }
 
   function defaultLinkColor(theme: "dark" | "light"): string {
@@ -1101,7 +1107,7 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
       text: options.text,
       style: {
         fill: options.fill,
-        fontFamily: "Goorm Sans, -apple-system, BlinkMacSystemFont, sans-serif",
+        fontFamily: labelFontFamily(),
         fontSize: options.fontSize,
         fontWeight: options.fontWeight,
       },
@@ -1754,7 +1760,15 @@ export default function GraphCanvasPixi(props: GraphCanvasProps): JSX.Element {
 
   createEffect(
     on(
-      () => [hoveredNode(), selectedNode(), showClusters(), getEffectiveTheme()] as const,
+      () =>
+        [
+          hoveredNode(),
+          selectedNode(),
+          showClusters(),
+          getEffectiveTheme(),
+          settingsState.editor.fontFamily,
+          currentLocale(),
+        ] as const,
       () => requestDraw({ links: true, clusters: true }),
       { defer: true },
     ),


### PR DESCRIPTION
## Summary

- **Switched to a single `Points` draw call**: Replaced per-node `Mesh` + `Sprite` rendering with one `THREE.Points` layer using a PSF (Point Spread Function) `ShaderMaterial`, reducing node rendering from N draw calls to 1.
- **O(n) hover/selection updates**: Node state changes now update typed-array buffer attributes directly instead of replacing material objects, removing GC pressure from hover and selection changes.
- **Optimized links**: Non-focused links now use `width=0`, which renders as plain 2-vertex `Line` objects and avoids cylinder meshes plus curvature segment generation.
- **Fibonacci-sphere cluster layout**: Cluster anchors are distributed evenly through 3D space instead of being constrained to a spiral galaxy plane.
- **Data-driven galaxy aesthetic**: Removed decorative glow sprites. The visual style now comes from the graph data itself: hub luminosity scales with `linkCount`, cluster force biases hubs toward dense cores, high-degree nodes get diffraction spikes, and vertex-shader distance falloff adds volumetric depth.
- **Background starfield**: Added deterministic starfield points, 1280 for full view and 420 for compact view, with per-star tinting and sine-based twinkle. A deterministic PRNG keeps star positions stable across theme changes.
- **Full theme support**: Dark mode uses `AdditiveBlending` with a deep-space gradient, while light mode uses `NormalBlending` with darker star pigments.

<details>
<summary> Original Korean </summary>

## Summary

- **단일 Points draw call로 전환**: 노드마다 Mesh+Sprite를 만들던 방식 → 전체 노드를 하나의 `THREE.Points` + PSF(Point Spread Function) ShaderMaterial로 렌더링. N draw calls → 1.
- **O(n) 호버/선택 업데이트**: 노드 상태 변경 시 material 객체 교체 없이 typed-array buffer attribute 직접 쓰기. GC 압력 제거.
- **링크 최적화**: 비포커스 링크를 width=0 (plain `Line` 2 vertices)으로 처리 — cylinder mesh + curvature segment 분할 완전 제거.
- **Fibonacci sphere 클러스터 배치**: 나선 은하 평면 대신 3D 공간 전체에 균일하게 cluster anchor 분배.
- **데이터 기반 galaxy 미학**: 장식용 glow sprite 없음. Hub luminosity ∝ linkCount, hub-biased cluster force(밀집 코어), 고차 노드에 diffraction spike, vertex shader 거리 감쇠로 volumetric 느낌.
- **배경 starfield**: 1280개(full) / 420개(compact) 포인트, per-star tint + sine twinkle, 결정론적 PRNG으로 테마 전환에도 안정적 위치 유지.
- **테마 완전 지원**: dark → AdditiveBlending + deep-space gradient, light → NormalBlending + 어두운 star pigment.

## Key constants

```ts
const STAR_SIZE_BASE = 6.5;
const STAR_SPIKE_MIN_LINKS = 5;
const GALAXY_ROTATION_SPEED = 0.015;
const STARFIELD_COUNT_FULL = 1280;
```

## Test plan

- [ ] Dark 테마에서 별들이 선명하게 보이는지 확인
- [ ] Light 테마에서 멍/번짐(additive blending artifact) 없는지 확인
- [ ] 노드 수 500+ 그래프에서 FPS 체감 개선 확인
- [ ] 노드 hover/click 정상 동작 (raycast proxy)
- [ ] locateNode (파일 이동 시 카메라 포커스) 정상 동작
- [ ] 테마 전환 시 별 위치 안정적으로 유지 (PRNG seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>